### PR TITLE
fix: upsert_solution 削除・ARCHITECTURE.md インポート記述修正

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -278,8 +278,8 @@ type SelectedElement =
 
 ### インポート
 
-- `summary_path` が同一のインポートは既存データを自動上書き（`upsert_solution` による）
-- `summary_path = None` のインポートは重複チェックなし（レガシー用途）
+- インポートは常に `insert_solution` で新規追加される（同一 `summary_path` でも上書きではなく別エントリとして追加）
+- `summary_path = None` のインポートも同様に新規追加（重複チェックなし）
 
 ### 検索
 

--- a/src-tauri/src/db/repository/mod.rs
+++ b/src-tauri/src/db/repository/mod.rs
@@ -2,7 +2,6 @@
 //!
 //! ## 主要関数
 //! - [`insert_solution`] — solution を作成し ID を返す
-//! - [`upsert_solution`] — summary_path 一致で既存削除→再挿入（上書きインポート）
 //! - [`insert_ddr_file`] — `DdrFile` をトランザクションで一括挿入
 //! - [`list_projects`] / [`delete_project`] — プロジェクト管理
 //! - [`list_solutions`] / [`delete_solution`] — ソリューション管理
@@ -19,8 +18,7 @@ mod solution;
 
 pub use solution::{
     delete_project, delete_solution, get_project, get_solution, get_solution_projects,
-    insert_solution, list_projects, list_solutions, upsert_solution, ProjectRow, SolutionRow,
-    SolutionWithProjects,
+    insert_solution, list_projects, list_solutions, ProjectRow, SolutionRow, SolutionWithProjects,
 };
 
 pub use import::{insert_ddr_file, insert_layout_object_condition};

--- a/src-tauri/src/db/repository/solution.rs
+++ b/src-tauri/src/db/repository/solution.rs
@@ -1,7 +1,6 @@
 //! ソリューション・プロジェクト CRUD 操作。
 
 use rusqlite::params;
-use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 
 use crate::db::{Database, DbError};
@@ -51,35 +50,6 @@ pub fn insert_solution(
         params![name, summary_path],
     )?;
     Ok(db.conn.last_insert_rowid())
-}
-
-/// `summary_path` が提供された場合、同一パスの既存 solution を削除してから INSERT する。
-/// `summary_path` が `None` のときは通常の INSERT（重複チェックなし）。
-pub fn upsert_solution(
-    db: &mut Database,
-    name: &str,
-    summary_path: Option<&str>,
-) -> Result<i64, DbError> {
-    let Some(path) = summary_path else {
-        return insert_solution(db, name, None);
-    };
-
-    // 既存 solution_id を取得
-    let existing_id: Option<i64> = db
-        .conn
-        .query_row(
-            "SELECT id FROM solutions WHERE summary_path = ?1 LIMIT 1",
-            params![path],
-            |row| row.get(0),
-        )
-        .optional()?;
-
-    // 既存があれば削除（FTS5 + CASCADE）
-    if let Some(old_id) = existing_id {
-        delete_solution(db, old_id)?;
-    }
-
-    insert_solution(db, name, Some(path))
 }
 
 /// ID で solution を1件取得する。
@@ -336,72 +306,5 @@ mod tests {
     fn delete_project_not_found_returns_err() {
         let mut db = Database::open_in_memory().unwrap();
         assert!(delete_project(&mut db, 9999).is_err());
-    }
-
-    // ---- upsert_solution ----
-
-    #[test]
-    fn upsert_solution_creates_new_when_no_existing() {
-        let mut db = Database::open_in_memory().unwrap();
-        let id = upsert_solution(&mut db, "TestDB", Some("/path/概要.xml")).unwrap();
-        let row = get_solution(&db, id).unwrap();
-        assert_eq!(row.name, "TestDB");
-        assert_eq!(row.summary_path.as_deref(), Some("/path/概要.xml"));
-    }
-
-    #[test]
-    fn upsert_solution_replaces_existing_with_same_path() {
-        let mut db = Database::open_in_memory().unwrap();
-        let path = "/path/概要.xml";
-        upsert_solution(&mut db, "FirstImport", Some(path)).unwrap();
-        let id2 = upsert_solution(&mut db, "SecondImport", Some(path)).unwrap();
-        let all = list_solutions(&db).unwrap();
-        let matched: Vec<_> = all
-            .iter()
-            .filter(|s| s.summary_path.as_deref() == Some(path))
-            .collect();
-        assert_eq!(matched.len(), 1);
-        assert_eq!(matched[0].id, id2);
-        assert_eq!(matched[0].name, "SecondImport");
-    }
-
-    #[test]
-    fn upsert_solution_cascades_old_projects() {
-        let (mut db, _sid, pid) = db_with_minimal();
-        let path = "/tmp/test.xml";
-        let _id2 = upsert_solution(&mut db, "TestSolution", Some(path)).unwrap();
-        assert!(get_project(&db, pid).is_err());
-    }
-
-    #[test]
-    fn upsert_solution_cleans_up_search_index() {
-        let (mut db, _sid, pid) = db_with_minimal();
-        let before: i64 = db
-            .conn
-            .query_row(
-                "SELECT COUNT(*) FROM search_index WHERE project_id=?1",
-                params![pid],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert!(before > 0);
-        upsert_solution(&mut db, "TestSolution", Some("/tmp/test.xml")).unwrap();
-        let after: i64 = db
-            .conn
-            .query_row(
-                "SELECT COUNT(*) FROM search_index WHERE project_id=?1",
-                params![pid],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(after, 0);
-    }
-
-    #[test]
-    fn upsert_solution_without_path_allows_duplicates() {
-        let mut db = Database::open_in_memory().unwrap();
-        let id1 = upsert_solution(&mut db, "TestDB", None).unwrap();
-        let id2 = upsert_solution(&mut db, "TestDB", None).unwrap();
-        assert_ne!(id1, id2);
     }
 }


### PR DESCRIPTION
## 概要

IMPROVEMENTS.md Step 1 の対応です。

## 変更内容

- `upsert_solution`（上書きインポート用 Dead Code）を `solution.rs` から削除
- 付属テスト5件も合わせて削除
- `repository/mod.rs` の re-export・docコメントから `upsert_solution` を削除
- `ARCHITECTURE.md` 7章のインポート記述を実際の動作（`insert_solution` で毎回新規追加）に修正

## 背景

`upsert_solution` は「同一パスの既存ソリューションを上書き」する関数として実装されていたが、現在どこからも呼ばれていない。上書きインポート機能の追加予定もないため削除。ARCHITECTURE.md に誤記（`upsert_solution` による自動上書きと記載）があったため合わせて修正。

## テスト

- `cargo test`: 294件 Green
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `npx tsc --noEmit`: clean
- `npm test`: 188件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)