### PR TITLE
feat: ddr_cache を LruCache に置き換えてメモリ上限を設ける

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1088,10 +1088,11 @@ dependencies = [
 
 [[package]]
 name = "filemaker-ddr-viewer"
-version = "1.2.2"
+version = "0.1.0"
 dependencies = [
  "assert_matches",
  "insta",
+ "lru",
  "petgraph",
  "proptest",
  "quick-xml 0.39.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ rayon = "1.11.0"
 thiserror = "2.0.18"
 tokio = { version = "1.50.0", features = ["full"] }
 tauri-plugin-dialog = "2.6.0"
+lru = "0.12"
 
 [lints.clippy]
 unwrap_used = "warn"

--- a/src-tauri/src/commands/callchain.rs
+++ b/src-tauri/src/commands/callchain.rs
@@ -27,9 +27,9 @@ pub(crate) fn get_ddr(
 ) -> Result<Arc<DdrFile>, CommandError> {
     // キャッシュから取得を試みる
     {
-        let cache = state
+        let mut cache = state
             .ddr_cache
-            .read()
+            .lock()
             .map_err(|e| CommandError::Internal(e.to_string()))?;
         if let Some(ddr) = cache.get(&project_id) {
             return Ok(Arc::clone(ddr));
@@ -63,9 +63,9 @@ pub(crate) fn get_ddr(
     // キャッシュに保存
     let mut cache = state
         .ddr_cache
-        .write()
+        .lock()
         .map_err(|e| CommandError::Internal(e.to_string()))?;
-    cache.insert(project_id, Arc::clone(&ddr_arc));
+    cache.put(project_id, Arc::clone(&ddr_arc));
 
     Ok(ddr_arc)
 }

--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -129,9 +129,9 @@ pub async fn import_solution(
         {
             let mut cache = state
                 .ddr_cache
-                .write()
+                .lock()
                 .map_err(|e| CommandError::Internal(e.to_string()))?;
-            cache.insert(project_id, Arc::clone(&ddr_arc));
+            cache.put(project_id, Arc::clone(&ddr_arc));
         }
     }
 
@@ -183,9 +183,9 @@ pub async fn import_ddr(
     {
         let mut cache = state
             .ddr_cache
-            .write()
+            .lock()
             .map_err(|e| CommandError::Internal(e.to_string()))?;
-        cache.insert(project_id, Arc::clone(&ddr_arc));
+        cache.put(project_id, Arc::clone(&ddr_arc));
     }
 
     // 5. ProjectRow を返す

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,11 +4,16 @@ pub mod db;
 pub mod parser;
 
 use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex, RwLock},
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
 };
 
+use lru::LruCache;
+
 use crate::{db::Database, parser::models::DdrFile};
+
+/// インメモリ DDR キャッシュの最大エントリ数。
+const DDR_CACHE_CAPACITY: usize = 10;
 
 // ---------------------------------------------------------------------------
 // アプリケーション状態
@@ -17,8 +22,8 @@ use crate::{db::Database, parser::models::DdrFile};
 /// Tauri アプリ全体で共有する状態。
 pub struct AppState {
     pub db: Mutex<Database>,
-    /// project_id → DdrFile のインメモリキャッシュ。
-    pub ddr_cache: RwLock<HashMap<i64, Arc<DdrFile>>>,
+    /// project_id → DdrFile のインメモリキャッシュ（LRU、上限 DDR_CACHE_CAPACITY 件）。
+    pub ddr_cache: Mutex<LruCache<i64, Arc<DdrFile>>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -49,7 +54,10 @@ pub fn run() {
             let db = Database::open(db_path.to_str().unwrap_or("fm_ddr.db"))?;
             app.manage(AppState {
                 db: Mutex::new(db),
-                ddr_cache: RwLock::new(HashMap::new()),
+                ddr_cache: Mutex::new(LruCache::new(
+                    NonZeroUsize::new(DDR_CACHE_CAPACITY)
+                        .expect("DDR_CACHE_CAPACITY must be non-zero"),
+                )),
             });
 
             // --------------- メニューバー構築 ---------------
@@ -170,4 +178,48 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ddr_cache_evicts_oldest_when_over_capacity() {
+        let capacity = NonZeroUsize::new(2).unwrap();
+        let mut cache: LruCache<i64, u32> = LruCache::new(capacity);
+
+        cache.put(1, 100);
+        cache.put(2, 200);
+        cache.put(3, 300); // 1 が evict される
+
+        assert!(
+            cache.get(&1).is_none(),
+            "最も古いエントリが evict されること"
+        );
+        assert_eq!(*cache.get(&2).unwrap(), 200);
+        assert_eq!(*cache.get(&3).unwrap(), 300);
+    }
+
+    #[test]
+    fn ddr_cache_get_updates_lru_order() {
+        let capacity = NonZeroUsize::new(2).unwrap();
+        let mut cache: LruCache<i64, u32> = LruCache::new(capacity);
+
+        cache.put(1, 100);
+        cache.put(2, 200);
+        cache.get(&1); // 1 を最近使用済みにする
+        cache.put(3, 300); // 2 が evict される（1 は守られる）
+
+        assert_eq!(
+            *cache.get(&1).unwrap(),
+            100,
+            "get 済みのエントリは evict されないこと"
+        );
+        assert!(
+            cache.get(&2).is_none(),
+            "アクセスしていないエントリが evict されること"
+        );
+        assert_eq!(*cache.get(&3).unwrap(), 300);
+    }
 }


### PR DESCRIPTION
## Summary

- `AppState.ddr_cache` を `RwLock<HashMap>` から `Mutex<LruCache>` に変更（上限10件）
- 大量インポート時の OOM リスクを解消
- `RwLock` → `Mutex` に統一（`LruCache::get()` が `&mut self` を要求するため）
- エビクション動作を確認する単体テスト2件を追加

## Test plan

- [ ] `ddr_cache_evicts_oldest_when_over_capacity` PASS
- [ ] `ddr_cache_get_updates_lru_order` PASS
- [ ] 全 298 テスト PASS
- [ ] `cargo clippy -- -D warnings` クリア
- [ ] `cargo fmt --check` クリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)