### PR TITLE
refactor: FieldDetail を8サブコンポーネントに分割、SearchFiltering フックを抽出

### DIFF
--- a/src/__tests__/SearchResults.test.tsx
+++ b/src/__tests__/SearchResults.test.tsx
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { SearchResults } from "../components/SearchResults";
+import { useSearchFiltering } from "../hooks/useSearchFiltering";
 import type { SearchResult } from "../types/ddr";
+import { SearchResults } from "../components/SearchResults";
 
 vi.mock("../hooks/useTauriCommand", () => ({
   useSearch: vi.fn(),
@@ -185,5 +187,62 @@ describe("SearchResults", () => {
       fieldId: 2,
       tableName: "Contact",
     });
+  });
+});
+
+const makeResult = (type: string, id: number): SearchResult => ({
+  project_id: 1,
+  element_type: type,
+  element_id: id,
+  name: `Item ${id}`,
+  snippet: "",
+  rank: 1.0,
+  parent_id: null,
+  parent_name: null,
+});
+
+describe("useSearchFiltering", () => {
+  const results: SearchResult[] = [
+    makeResult("script", 1),
+    makeResult("script", 2),
+    makeResult("field", 3),
+  ];
+
+  it("returns_all_results_when_no_filter", () => {
+    const { result } = renderHook(() => useSearchFiltering(results));
+    expect(result.current.filteredResults).toHaveLength(3);
+    expect(result.current.activeType).toBeNull();
+  });
+
+  it("counts_by_type_correctly", () => {
+    const { result } = renderHook(() => useSearchFiltering(results));
+    expect(result.current.countsByType["script"]).toBe(2);
+    expect(result.current.countsByType["field"]).toBe(1);
+  });
+
+  it("filters_by_type_when_activeType_set", () => {
+    const { result } = renderHook(() => useSearchFiltering(results));
+    act(() => {
+      result.current.setActiveType("script");
+    });
+    expect(result.current.filteredResults).toHaveLength(2);
+    expect(result.current.filteredResults.every((r) => r.element_type === "script")).toBe(true);
+  });
+
+  it("resets_to_all_when_activeType_set_to_null", () => {
+    const { result } = renderHook(() => useSearchFiltering(results));
+    act(() => {
+      result.current.setActiveType("script");
+    });
+    act(() => {
+      result.current.setActiveType(null);
+    });
+    expect(result.current.filteredResults).toHaveLength(3);
+  });
+
+  it("returns_empty_array_for_empty_results", () => {
+    const { result } = renderHook(() => useSearchFiltering([]));
+    expect(result.current.filteredResults).toHaveLength(0);
+    expect(result.current.countsByType).toEqual({});
   });
 });

--- a/src/__tests__/detail/FieldDetail.test.tsx
+++ b/src/__tests__/detail/FieldDetail.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FieldDetail } from "../../components/detail/FieldDetail";
+import { makeFieldRow } from "../testFixtures";
+
+vi.mock("../../hooks/useTauriCommand", () => ({
+  useFieldRefs: vi.fn(() => ({ data: [], isLoading: false })),
+  useFieldCalcRefs: vi.fn(() => ({ data: [], isLoading: false })),
+  useFieldLayoutRefs: vi.fn(() => ({ data: [], isLoading: false })),
+  useFieldRelationshipKeys: vi.fn(() => ({ data: [], isLoading: false })),
+  useLayoutRefDebugInfo: vi.fn(() => ({ data: undefined })),
+  useScriptList: vi.fn(() => ({ data: [] })),
+  useLayoutList: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock("../../stores/appStore", () => ({
+  useAppStore: vi.fn(() => ({
+    selectElement: vi.fn(),
+    setRightPanel: vi.fn(),
+  })),
+}));
+
+const defaultProps = {
+  field: makeFieldRow(),
+  tableName: "TestTable",
+  projectId: 1,
+};
+
+describe("FieldDetail", () => {
+  it("renders_basic_properties_section", () => {
+    render(<FieldDetail {...defaultProps} />);
+    expect(screen.getByText("フィールドプロパティ")).toBeInTheDocument();
+    expect(screen.getByText("TestField")).toBeInTheDocument();
+  });
+
+  it("renders_all_reference_sections", () => {
+    render(<FieldDetail {...defaultProps} />);
+    expect(screen.getByText("計算フィールドとして使用されている箇所")).toBeInTheDocument();
+    expect(screen.getByText("スクリプト使用箇所")).toBeInTheDocument();
+    expect(screen.getByText("レイアウト使用箇所")).toBeInTheDocument();
+    expect(screen.getByText("リレーションキー使用箇所")).toBeInTheDocument();
+  });
+
+  it("does_not_render_auto_enter_when_empty", () => {
+    render(<FieldDetail {...defaultProps} field={makeFieldRow({ auto_enter_type: "" })} />);
+    expect(screen.queryByText("自動入力")).not.toBeInTheDocument();
+  });
+
+  it("renders_auto_enter_when_set", () => {
+    render(
+      <FieldDetail
+        {...defaultProps}
+        field={makeFieldRow({ auto_enter_type: "Serial" })}
+      />
+    );
+    expect(screen.getByText("自動入力")).toBeInTheDocument();
+    expect(screen.getByText("シリアル番号")).toBeInTheDocument();
+  });
+
+  it("does_not_render_validation_when_none", () => {
+    render(<FieldDetail {...defaultProps} />);
+    expect(screen.queryByText("入力値の制限")).not.toBeInTheDocument();
+  });
+
+  it("renders_validation_when_not_empty", () => {
+    render(
+      <FieldDetail
+        {...defaultProps}
+        field={makeFieldRow({ val_not_empty: true })}
+      />
+    );
+    expect(screen.getByText("入力値の制限")).toBeInTheDocument();
+    expect(screen.getByText("入力必須")).toBeInTheDocument();
+  });
+
+  it("does_not_render_storage_when_none", () => {
+    render(<FieldDetail {...defaultProps} field={makeFieldRow({ index_type: "", container_storage: null })} />);
+    expect(screen.queryByText("ストレージ")).not.toBeInTheDocument();
+  });
+
+  it("renders_storage_when_index_type_set", () => {
+    render(
+      <FieldDetail
+        {...defaultProps}
+        field={makeFieldRow({ index_type: "All" })}
+      />
+    );
+    expect(screen.getByText("ストレージ")).toBeInTheDocument();
+    expect(screen.getByText("全て")).toBeInTheDocument();
+  });
+
+  it("shows_empty_message_for_script_refs", () => {
+    render(<FieldDetail {...defaultProps} />);
+    expect(
+      screen.getByText("このフィールドを参照するスクリプトはありません")
+    ).toBeInTheDocument();
+  });
+
+  it("shows_loading_spinner_for_calc_refs", async () => {
+    const { useFieldCalcRefs } = await import("../../hooks/useTauriCommand");
+    vi.mocked(useFieldCalcRefs).mockReturnValue(
+      { data: [], isLoading: true } as unknown as ReturnType<typeof useFieldCalcRefs>
+    );
+    render(<FieldDetail {...defaultProps} />);
+    expect(screen.getAllByText("読み込み中...").length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { Spinner } from "./Spinner";
 import { useSearch } from "../hooks/useTauriCommand";
 import { useAppStore } from "../stores/appStore";
+import { useSearchFiltering } from "../hooks/useSearchFiltering";
 import type { SearchResult } from "../types/ddr";
 
 function escapeRegex(str: string): string {
@@ -63,7 +64,8 @@ export function SearchResults({ query }: Props) {
     searchScope,
     selectedSolution?.id ?? null,
   );
-  const [activeType, setActiveType] = useState<string | null>(null);
+  const { activeType, setActiveType, countsByType, filteredResults } =
+    useSearchFiltering(results ?? []);
   const searchStartRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -87,16 +89,6 @@ export function SearchResults({ query }: Props) {
       <div className="text-gray-400 text-sm p-4">見つかりませんでした</div>
     );
   }
-
-  // カテゴリ別件数
-  const countsByType: Record<string, number> = {};
-  for (const r of results) {
-    countsByType[r.element_type] = (countsByType[r.element_type] ?? 0) + 1;
-  }
-
-  const filteredResults = activeType
-    ? results.filter((r) => r.element_type === activeType)
-    : results;
 
   function handleClick(result: SearchResult) {
     const pid = result.project_id;

--- a/src/components/detail/FieldDetail.tsx
+++ b/src/components/detail/FieldDetail.tsx
@@ -1,42 +1,13 @@
 // src/components/detail/FieldDetail.tsx
 import type { FieldRow } from "../../types/ddr";
-import { Spinner } from "../Spinner";
-
-const AUTO_ENTER_LABEL: Record<string, string> = {
-  Calculation:              "計算式",
-  ConstantData:             "定数",
-  Serial:                   "シリアル番号",
-  Lookup:                   "参照",
-  ModificationTimeStamp:    "更新タイムスタンプ",
-  ModificationDate:         "更新日",
-  ModificationTime:         "更新時刻",
-  ModificationAccountName:  "更新アカウント名",
-  CreationTimeStamp:        "作成タイムスタンプ",
-  CreationDate:             "作成日",
-  CreationTime:             "作成時刻",
-  CreationAccountName:      "作成アカウント名",
-};
-
-const INDEX_LABEL: Record<string, string> = {
-  All:     "全て",
-  Minimal: "最小",
-  None:    "なし",
-};
-
-function parseSerialInfo(calc: string): string {
-  const kv: Record<string, string> = {};
-  for (const token of calc.split(",")) {
-    const eq = token.indexOf("=");
-    if (eq >= 0) kv[token.slice(0, eq).trim()] = token.slice(eq + 1).trim();
-  }
-  const gen = kv["generate"] === "OnCreation" ? "作成時"
-            : kv["generate"] === "OnCommit"   ? "確定時"
-            : (kv["generate"] ?? "");
-  return `次の値: ${kv["nextValue"] ?? "?"} / 増分: ${kv["increment"] ?? "?"} / 生成: ${gen}`;
-}
-import { useFieldRefs, useFieldCalcRefs, useFieldLayoutRefs, useFieldRelationshipKeys, useLayoutRefDebugInfo, useScriptList, useLayoutList } from "../../hooks/useTauriCommand";
-import { useAppStore } from "../../stores/appStore";
-import { BADGE_VARIANTS, CODE_BLOCK, SECTION_HEADER } from "../../styles/tokens";
+import { FieldBasicProperties } from "./field/FieldBasicProperties";
+import { FieldAutoEnter } from "./field/FieldAutoEnter";
+import { FieldValidationRules } from "./field/FieldValidationRules";
+import { FieldStorage } from "./field/FieldStorage";
+import { FieldCalcReferences } from "./field/FieldCalcReferences";
+import { FieldScriptReferences } from "./field/FieldScriptReferences";
+import { FieldLayoutReferences } from "./field/FieldLayoutReferences";
+import { FieldRelationshipReferences } from "./field/FieldRelationshipReferences";
 
 interface Props {
   field: FieldRow;
@@ -45,330 +16,32 @@ interface Props {
 }
 
 export function FieldDetail({ field, tableName, projectId }: Props) {
-  const { selectElement, setRightPanel } = useAppStore();
-  const { data: refs = [], isLoading: refsLoading } = useFieldRefs(
-    projectId,
-    tableName,
-    field.name
-  );
-  const { data: layoutRefs = [], isLoading: layoutRefsLoading } = useFieldLayoutRefs(
-    projectId,
-    tableName,
-    field.name
-  );
-  const { data: relKeyRefs = [], isLoading: relKeyLoading } = useFieldRelationshipKeys(
-    projectId,
-    tableName,
-    field.name
-  );
-  const { data: calcRefs = [], isLoading: calcRefsLoading } = useFieldCalcRefs(
-    projectId,
-    tableName,
-    field.name
-  );
-  const { data: debugInfo } = useLayoutRefDebugInfo(projectId);
-  const { data: scripts = [] } = useScriptList(projectId);
-  const { data: layouts = [] } = useLayoutList(projectId);
-
-  function handleScriptClick(scriptName: string) {
-    const script = scripts.find((s) => s.name === scriptName);
-    if (script) {
-      selectElement({ kind: "script", projectId, id: script.id, name: script.name });
-    }
-  }
-
-  function handleLayoutClick(layoutName: string) {
-    const layout = layouts.find((l) => l.name === layoutName);
-    if (layout) {
-      selectElement({ kind: "layout", projectId, id: layout.id, name: layout.name });
-    }
-  }
-
-  function handleCalcFieldClick(refTableId: number, refFieldId: number, refTableName: string) {
-    setRightPanel({ kind: "field", projectId, tableId: refTableId, fieldId: refFieldId, tableName: refTableName });
-  }
-
   return (
     <div className="p-4 space-y-4 text-sm">
-      {/* フィールドプロパティ */}
-      <section>
-        <h4 className={SECTION_HEADER}>フィールドプロパティ</h4>
-        <dl className="space-y-1">
-          <div className="flex gap-2">
-            <dt className="text-gray-500 w-24 shrink-0">名前</dt>
-            <dd className="font-medium text-gray-900 break-all">{field.name}</dd>
-          </div>
-          <div className="flex gap-2">
-            <dt className="text-gray-500 w-24 shrink-0">データ型</dt>
-            <dd>
-              <span className={BADGE_VARIANTS.purple}>{field.data_type}</span>
-            </dd>
-          </div>
-          <div className="flex gap-2">
-            <dt className="text-gray-500 w-24 shrink-0">種別</dt>
-            <dd>
-              <span className={BADGE_VARIANTS.gray}>{field.field_type}</span>
-            </dd>
-          </div>
-          {field.is_global && (
-            <div className="flex gap-2">
-              <dt className="text-gray-500 w-24 shrink-0">グローバル</dt>
-              <dd>
-                <span className={BADGE_VARIANTS.blue}>Global</span>
-              </dd>
-            </div>
-          )}
-          {field.max_repeat > 1 && (
-            <div className="flex gap-2">
-              <dt className="text-gray-500 w-24 shrink-0">繰り返し</dt>
-              <dd className="text-gray-900">{field.max_repeat}</dd>
-            </div>
-          )}
-          {field.comment && (
-            <div className="flex gap-2">
-              <dt className="text-gray-500 w-24 shrink-0">コメント</dt>
-              <dd className="text-gray-700 break-all">{field.comment}</dd>
-            </div>
-          )}
-          {field.calculation && (
-            <div className="flex flex-col gap-1">
-              <dt className="text-gray-500">計算式</dt>
-              <dd className={CODE_BLOCK}>{field.calculation}</dd>
-            </div>
-          )}
-        </dl>
-      </section>
-
-      {/* 自動入力 */}
-      {field.auto_enter_type !== "" && (
-        <section>
-          <h4 className={SECTION_HEADER}>自動入力</h4>
-          <dl className="space-y-1">
-            <div className="flex gap-2">
-              <dt className="text-gray-500 w-24 shrink-0">種別</dt>
-              <dd>
-                <span className={BADGE_VARIANTS.blue}>{AUTO_ENTER_LABEL[field.auto_enter_type] ?? field.auto_enter_type}</span>
-              </dd>
-            </div>
-            {!field.auto_enter_allow_editing && (
-              <div className="flex gap-2">
-                <dt className="text-gray-500 w-24 shrink-0">編集</dt>
-                <dd><span className={BADGE_VARIANTS.gray}>編集不可</span></dd>
-              </div>
-            )}
-            {field.auto_enter_calc && (
-              <div className="flex flex-col gap-1">
-                <dt className="text-gray-500">
-                  {field.auto_enter_type === "Serial" ? "シリアル情報" : "計算式 / 値"}
-                </dt>
-                <dd className={CODE_BLOCK}>
-                  {field.auto_enter_type === "Serial"
-                    ? parseSerialInfo(field.auto_enter_calc)
-                    : field.auto_enter_calc}
-                </dd>
-              </div>
-            )}
-          </dl>
-        </section>
-      )}
-
-      {/* 入力値の制限 */}
-      {(field.val_not_empty || field.val_unique || field.val_existing ||
-        field.val_max_length != null || field.val_value_list ||
-        field.val_calc || field.val_range_from || field.val_range_to ||
-        field.val_error_message) && (
-        <section>
-          <h4 className={SECTION_HEADER}>入力値の制限</h4>
-          <dl className="space-y-1">
-            {(field.val_not_empty || field.val_unique || field.val_existing) && (
-              <div className="flex gap-2 flex-wrap">
-                <dt className="text-gray-500 w-24 shrink-0">種別</dt>
-                <dd className="flex gap-1 flex-wrap">
-                  {field.val_not_empty && <span className={BADGE_VARIANTS.red}>入力必須</span>}
-                  {field.val_unique && <span className={BADGE_VARIANTS.yellow}>重複不可</span>}
-                  {field.val_existing && <span className={BADGE_VARIANTS.gray}>既存値のみ</span>}
-                </dd>
-              </div>
-            )}
-            {field.val_always && (
-              <div className="flex gap-2">
-                <dt className="text-gray-500 w-24 shrink-0">タイミング</dt>
-                <dd><span className={BADGE_VARIANTS.gray}>常に</span></dd>
-              </div>
-            )}
-            {field.val_max_length != null && (
-              <div className="flex gap-2">
-                <dt className="text-gray-500 w-24 shrink-0">最大文字数</dt>
-                <dd className="text-gray-900">{field.val_max_length}</dd>
-              </div>
-            )}
-            {field.val_value_list && (
-              <div className="flex gap-2">
-                <dt className="text-gray-500 w-24 shrink-0">値一覧</dt>
-                <dd className="text-gray-900">{field.val_value_list}</dd>
-              </div>
-            )}
-            {(field.val_range_from != null || field.val_range_to != null) && (
-              <div className="flex gap-2">
-                <dt className="text-gray-500 w-24 shrink-0">範囲</dt>
-                <dd className="text-gray-900">
-                  {field.val_range_from ?? "?"} 〜 {field.val_range_to ?? "?"}
-                </dd>
-              </div>
-            )}
-            {field.val_calc && (
-              <div className="flex flex-col gap-1">
-                <dt className="text-gray-500">計算式</dt>
-                <dd className={CODE_BLOCK}>{field.val_calc}</dd>
-              </div>
-            )}
-            {field.val_error_message && (
-              <div className="flex gap-2">
-                <dt className="text-gray-500 w-24 shrink-0">エラーメッセージ</dt>
-                <dd className="text-gray-700 break-all">{field.val_error_message}</dd>
-              </div>
-            )}
-          </dl>
-        </section>
-      )}
-
-      {/* ストレージ */}
-      {(field.index_type || field.container_storage) && (
-        <section>
-          <h4 className={SECTION_HEADER}>ストレージ</h4>
-          <dl className="space-y-1">
-            {field.container_storage && (
-              <div className="flex gap-2">
-                <dt className="text-gray-500 w-24 shrink-0">保存方法</dt>
-                <dd>
-                  <span className={BADGE_VARIANTS.purple}>
-                    {field.container_storage === "Internal" && "内部格納"}
-                    {field.container_storage === "Secure"   && "外部格納（セキュア）"}
-                    {field.container_storage === "Open"     && "外部格納（オープン）"}
-                  </span>
-                </dd>
-              </div>
-            )}
-            {field.index_type && (
-              <div className="flex gap-2">
-                <dt className="text-gray-500 w-24 shrink-0">インデックス</dt>
-                <dd>
-                  <span className={BADGE_VARIANTS.gray}>
-                    {INDEX_LABEL[field.index_type] ?? field.index_type}
-                  </span>
-                </dd>
-              </div>
-            )}
-          </dl>
-        </section>
-      )}
-
-      {/* 計算フィールドとして使用されている箇所 */}
-      <section>
-        <h4 className={SECTION_HEADER}>計算フィールドとして使用されている箇所</h4>
-        {calcRefsLoading ? (
-          <span className="flex items-center gap-1 text-gray-400 text-xs"><Spinner className="w-3 h-3" />読み込み中...</span>
-        ) : calcRefs.length === 0 ? (
-          <p className="text-gray-400 text-xs">他のフィールドの計算式で参照されていません</p>
-        ) : (
-          <ul className="space-y-1">
-            {calcRefs.map((ref) => (
-              <li key={ref.field_id}>
-                <button
-                  className="text-blue-600 hover:underline text-left break-all w-full"
-                  onClick={() => handleCalcFieldClick(ref.table_id, ref.field_id, ref.table_name)}
-                >
-                  {ref.table_name}::{ref.field_name}
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-
-      {/* スクリプト使用箇所 */}
-      <section>
-        <h4 className={SECTION_HEADER}>スクリプト使用箇所</h4>
-        {refsLoading ? (
-          <span className="flex items-center gap-1 text-gray-400 text-xs"><Spinner className="w-3 h-3" />読み込み中...</span>
-        ) : refs.length === 0 ? (
-          <p className="text-gray-400 text-xs">このフィールドを参照するスクリプトはありません</p>
-        ) : (
-          <ul className="space-y-1">
-            {refs.map((ref) => (
-              <li key={ref.script_id}>
-                <button
-                  className="text-blue-600 hover:underline text-left break-all w-full"
-                  onClick={() => handleScriptClick(ref.script_name)}
-                >
-                  {ref.script_name}
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-
-      {/* レイアウト使用箇所 */}
-      <section>
-        <h4 className={SECTION_HEADER}>レイアウト使用箇所</h4>
-        {layoutRefsLoading ? (
-          <span className="flex items-center gap-1 text-gray-400 text-xs"><Spinner className="w-3 h-3" />読み込み中...</span>
-        ) : layoutRefs.length === 0 ? (
-          <div className="space-y-1">
-            <p className="text-gray-400 text-xs">このフィールドが配置されているレイアウトはありません</p>
-            {debugInfo && (debugInfo.occurrence_count === 0 || debugInfo.layout_field_ref_count === 0) && (
-              <div className="bg-amber-50 border border-amber-200 rounded p-2 text-xs text-amber-700">
-                <p className="font-semibold mb-1">⚠ DDRの再インポートが必要です</p>
-                <p>オカレンスデータ: {debugInfo.occurrence_count}件</p>
-                <p>レイアウトフィールドデータ: {debugInfo.layout_field_ref_count}件</p>
-                <p className="mt-1 text-amber-600">スキーマ更新後に初めてインポートしたDDRでのみ有効です。既存のDDRは削除して再インポートしてください。</p>
-              </div>
-            )}
-          </div>
-        ) : (
-          <ul className="space-y-1">
-            {layoutRefs.map((ref) => (
-              <li key={ref.layout_id}>
-                <button
-                  className="text-blue-600 hover:underline text-left break-all w-full"
-                  onClick={() => handleLayoutClick(ref.layout_name)}
-                >
-                  {ref.layout_name}
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-      {/* リレーションキー使用箇所 */}
-      <section>
-        <h4 className={SECTION_HEADER}>リレーションキー使用箇所</h4>
-        {relKeyLoading ? (
-          <span className="flex items-center gap-1 text-gray-400 text-xs"><Spinner className="w-3 h-3" />読み込み中...</span>
-        ) : relKeyRefs.length === 0 ? (
-          <p className="text-gray-400 text-xs">リレーションキーとして使用されていません</p>
-        ) : (
-          <ul className="space-y-1">
-            {relKeyRefs.map((ref) => (
-              <li key={`${ref.relationship_id}-${ref.side}`}>
-                <button
-                  className="w-full flex items-center gap-2 text-xs hover:bg-blue-50 rounded px-1 py-0.5 transition-colors text-left"
-                  onClick={() => selectElement({ kind: "all_relationships", projectId, highlightId: ref.relationship_id })}
-                >
-                  <span className={ref.side === "left" ? BADGE_VARIANTS.blue : BADGE_VARIANTS.green}>
-                    {ref.side === "left" ? "左" : "右"}
-                  </span>
-                  <span className="font-medium text-gray-800">{ref.relationship_name}</span>
-                  <span className="text-gray-400">
-                    {ref.left_table} {ref.operator} {ref.right_table}
-                  </span>
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+      <FieldBasicProperties field={field} />
+      <FieldAutoEnter field={field} />
+      <FieldValidationRules field={field} />
+      <FieldStorage field={field} />
+      <FieldCalcReferences
+        projectId={projectId}
+        tableName={tableName}
+        fieldName={field.name}
+      />
+      <FieldScriptReferences
+        projectId={projectId}
+        tableName={tableName}
+        fieldName={field.name}
+      />
+      <FieldLayoutReferences
+        projectId={projectId}
+        tableName={tableName}
+        fieldName={field.name}
+      />
+      <FieldRelationshipReferences
+        projectId={projectId}
+        tableName={tableName}
+        fieldName={field.name}
+      />
     </div>
   );
 }

--- a/src/components/detail/field/FieldAutoEnter.tsx
+++ b/src/components/detail/field/FieldAutoEnter.tsx
@@ -1,0 +1,76 @@
+import type { FieldRow } from "../../../types/ddr";
+import { BADGE_VARIANTS, CODE_BLOCK, SECTION_HEADER } from "../../../styles/tokens";
+
+const AUTO_ENTER_LABEL: Record<string, string> = {
+  Calculation:             "計算式",
+  ConstantData:            "定数",
+  Serial:                  "シリアル番号",
+  Lookup:                  "参照",
+  ModificationTimeStamp:   "更新タイムスタンプ",
+  ModificationDate:        "更新日",
+  ModificationTime:        "更新時刻",
+  ModificationAccountName: "更新アカウント名",
+  CreationTimeStamp:       "作成タイムスタンプ",
+  CreationDate:            "作成日",
+  CreationTime:            "作成時刻",
+  CreationAccountName:     "作成アカウント名",
+};
+
+function parseSerialInfo(calc: string): string {
+  const kv: Record<string, string> = {};
+  for (const token of calc.split(",")) {
+    const eq = token.indexOf("=");
+    if (eq >= 0) kv[token.slice(0, eq).trim()] = token.slice(eq + 1).trim();
+  }
+  const gen =
+    kv["generate"] === "OnCreation"
+      ? "作成時"
+      : kv["generate"] === "OnCommit"
+        ? "確定時"
+        : (kv["generate"] ?? "");
+  return `次の値: ${kv["nextValue"] ?? "?"} / 増分: ${kv["increment"] ?? "?"} / 生成: ${gen}`;
+}
+
+interface Props {
+  field: FieldRow;
+}
+
+export function FieldAutoEnter({ field }: Props) {
+  if (field.auto_enter_type === "") return null;
+
+  return (
+    <section>
+      <h4 className={SECTION_HEADER}>自動入力</h4>
+      <dl className="space-y-1">
+        <div className="flex gap-2">
+          <dt className="text-gray-500 w-24 shrink-0">種別</dt>
+          <dd>
+            <span className={BADGE_VARIANTS.blue}>
+              {AUTO_ENTER_LABEL[field.auto_enter_type] ?? field.auto_enter_type}
+            </span>
+          </dd>
+        </div>
+        {!field.auto_enter_allow_editing && (
+          <div className="flex gap-2">
+            <dt className="text-gray-500 w-24 shrink-0">編集</dt>
+            <dd>
+              <span className={BADGE_VARIANTS.gray}>編集不可</span>
+            </dd>
+          </div>
+        )}
+        {field.auto_enter_calc && (
+          <div className="flex flex-col gap-1">
+            <dt className="text-gray-500">
+              {field.auto_enter_type === "Serial" ? "シリアル情報" : "計算式 / 値"}
+            </dt>
+            <dd className={CODE_BLOCK}>
+              {field.auto_enter_type === "Serial"
+                ? parseSerialInfo(field.auto_enter_calc)
+                : field.auto_enter_calc}
+            </dd>
+          </div>
+        )}
+      </dl>
+    </section>
+  );
+}

--- a/src/components/detail/field/FieldBasicProperties.tsx
+++ b/src/components/detail/field/FieldBasicProperties.tsx
@@ -1,0 +1,58 @@
+import type { FieldRow } from "../../../types/ddr";
+import { BADGE_VARIANTS, CODE_BLOCK, SECTION_HEADER } from "../../../styles/tokens";
+
+interface Props {
+  field: FieldRow;
+}
+
+export function FieldBasicProperties({ field }: Props) {
+  return (
+    <section>
+      <h4 className={SECTION_HEADER}>フィールドプロパティ</h4>
+      <dl className="space-y-1">
+        <div className="flex gap-2">
+          <dt className="text-gray-500 w-24 shrink-0">名前</dt>
+          <dd className="font-medium text-gray-900 break-all">{field.name}</dd>
+        </div>
+        <div className="flex gap-2">
+          <dt className="text-gray-500 w-24 shrink-0">データ型</dt>
+          <dd>
+            <span className={BADGE_VARIANTS.purple}>{field.data_type}</span>
+          </dd>
+        </div>
+        <div className="flex gap-2">
+          <dt className="text-gray-500 w-24 shrink-0">種別</dt>
+          <dd>
+            <span className={BADGE_VARIANTS.gray}>{field.field_type}</span>
+          </dd>
+        </div>
+        {field.is_global && (
+          <div className="flex gap-2">
+            <dt className="text-gray-500 w-24 shrink-0">グローバル</dt>
+            <dd>
+              <span className={BADGE_VARIANTS.blue}>Global</span>
+            </dd>
+          </div>
+        )}
+        {field.max_repeat > 1 && (
+          <div className="flex gap-2">
+            <dt className="text-gray-500 w-24 shrink-0">繰り返し</dt>
+            <dd className="text-gray-900">{field.max_repeat}</dd>
+          </div>
+        )}
+        {field.comment && (
+          <div className="flex gap-2">
+            <dt className="text-gray-500 w-24 shrink-0">コメント</dt>
+            <dd className="text-gray-700 break-all">{field.comment}</dd>
+          </div>
+        )}
+        {field.calculation && (
+          <div className="flex flex-col gap-1">
+            <dt className="text-gray-500">計算式</dt>
+            <dd className={CODE_BLOCK}>{field.calculation}</dd>
+          </div>
+        )}
+      </dl>
+    </section>
+  );
+}

--- a/src/components/detail/field/FieldCalcReferences.tsx
+++ b/src/components/detail/field/FieldCalcReferences.tsx
@@ -1,0 +1,54 @@
+import { useFieldCalcRefs } from "../../../hooks/useTauriCommand";
+import { useAppStore } from "../../../stores/appStore";
+import { Spinner } from "../../Spinner";
+import { SECTION_HEADER } from "../../../styles/tokens";
+
+interface Props {
+  projectId: number;
+  tableName: string;
+  fieldName: string;
+}
+
+export function FieldCalcReferences({ projectId, tableName, fieldName }: Props) {
+  const { setRightPanel } = useAppStore();
+  const { data: calcRefs = [], isLoading } = useFieldCalcRefs(
+    projectId,
+    tableName,
+    fieldName
+  );
+
+  return (
+    <section>
+      <h4 className={SECTION_HEADER}>計算フィールドとして使用されている箇所</h4>
+      {isLoading ? (
+        <span className="flex items-center gap-1 text-gray-400 text-xs">
+          <Spinner className="w-3 h-3" />
+          読み込み中...
+        </span>
+      ) : calcRefs.length === 0 ? (
+        <p className="text-gray-400 text-xs">他のフィールドの計算式で参照されていません</p>
+      ) : (
+        <ul className="space-y-1">
+          {calcRefs.map((ref) => (
+            <li key={ref.field_id}>
+              <button
+                className="text-blue-600 hover:underline text-left break-all w-full"
+                onClick={() =>
+                  setRightPanel({
+                    kind: "field",
+                    projectId,
+                    tableId: ref.table_id,
+                    fieldId: ref.field_id,
+                    tableName: ref.table_name,
+                  })
+                }
+              >
+                {ref.table_name}::{ref.field_name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/detail/field/FieldLayoutReferences.tsx
+++ b/src/components/detail/field/FieldLayoutReferences.tsx
@@ -1,0 +1,75 @@
+import {
+  useFieldLayoutRefs,
+  useLayoutList,
+  useLayoutRefDebugInfo,
+} from "../../../hooks/useTauriCommand";
+import { useAppStore } from "../../../stores/appStore";
+import { Spinner } from "../../Spinner";
+import { SECTION_HEADER } from "../../../styles/tokens";
+
+interface Props {
+  projectId: number;
+  tableName: string;
+  fieldName: string;
+}
+
+export function FieldLayoutReferences({ projectId, tableName, fieldName }: Props) {
+  const { selectElement } = useAppStore();
+  const { data: layoutRefs = [], isLoading } = useFieldLayoutRefs(
+    projectId,
+    tableName,
+    fieldName
+  );
+  const { data: layouts = [] } = useLayoutList(projectId);
+  const { data: debugInfo } = useLayoutRefDebugInfo(projectId);
+
+  function handleLayoutClick(layoutName: string) {
+    const layout = layouts.find((l) => l.name === layoutName);
+    if (layout) {
+      selectElement({ kind: "layout", projectId, id: layout.id, name: layout.name });
+    }
+  }
+
+  return (
+    <section>
+      <h4 className={SECTION_HEADER}>レイアウト使用箇所</h4>
+      {isLoading ? (
+        <span className="flex items-center gap-1 text-gray-400 text-xs">
+          <Spinner className="w-3 h-3" />
+          読み込み中...
+        </span>
+      ) : layoutRefs.length === 0 ? (
+        <div className="space-y-1">
+          <p className="text-gray-400 text-xs">
+            このフィールドが配置されているレイアウトはありません
+          </p>
+          {debugInfo &&
+            (debugInfo.occurrence_count === 0 ||
+              debugInfo.layout_field_ref_count === 0) && (
+              <div className="bg-amber-50 border border-amber-200 rounded p-2 text-xs text-amber-700">
+                <p className="font-semibold mb-1">⚠ DDRの再インポートが必要です</p>
+                <p>オカレンスデータ: {debugInfo.occurrence_count}件</p>
+                <p>レイアウトフィールドデータ: {debugInfo.layout_field_ref_count}件</p>
+                <p className="mt-1 text-amber-600">
+                  スキーマ更新後に初めてインポートしたDDRでのみ有効です。既存のDDRは削除して再インポートしてください。
+                </p>
+              </div>
+            )}
+        </div>
+      ) : (
+        <ul className="space-y-1">
+          {layoutRefs.map((ref) => (
+            <li key={ref.layout_id}>
+              <button
+                className="text-blue-600 hover:underline text-left break-all w-full"
+                onClick={() => handleLayoutClick(ref.layout_name)}
+              >
+                {ref.layout_name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/detail/field/FieldRelationshipReferences.tsx
+++ b/src/components/detail/field/FieldRelationshipReferences.tsx
@@ -1,0 +1,62 @@
+import { useFieldRelationshipKeys } from "../../../hooks/useTauriCommand";
+import { useAppStore } from "../../../stores/appStore";
+import { Spinner } from "../../Spinner";
+import { BADGE_VARIANTS, SECTION_HEADER } from "../../../styles/tokens";
+
+interface Props {
+  projectId: number;
+  tableName: string;
+  fieldName: string;
+}
+
+export function FieldRelationshipReferences({ projectId, tableName, fieldName }: Props) {
+  const { selectElement } = useAppStore();
+  const { data: relKeyRefs = [], isLoading } = useFieldRelationshipKeys(
+    projectId,
+    tableName,
+    fieldName
+  );
+
+  return (
+    <section>
+      <h4 className={SECTION_HEADER}>リレーションキー使用箇所</h4>
+      {isLoading ? (
+        <span className="flex items-center gap-1 text-gray-400 text-xs">
+          <Spinner className="w-3 h-3" />
+          読み込み中...
+        </span>
+      ) : relKeyRefs.length === 0 ? (
+        <p className="text-gray-400 text-xs">リレーションキーとして使用されていません</p>
+      ) : (
+        <ul className="space-y-1">
+          {relKeyRefs.map((ref) => (
+            <li key={`${ref.relationship_id}-${ref.side}`}>
+              <button
+                className="w-full flex items-center gap-2 text-xs hover:bg-blue-50 rounded px-1 py-0.5 transition-colors text-left"
+                onClick={() =>
+                  selectElement({
+                    kind: "all_relationships",
+                    projectId,
+                    highlightId: ref.relationship_id,
+                  })
+                }
+              >
+                <span
+                  className={
+                    ref.side === "left" ? BADGE_VARIANTS.blue : BADGE_VARIANTS.green
+                  }
+                >
+                  {ref.side === "left" ? "左" : "右"}
+                </span>
+                <span className="font-medium text-gray-800">{ref.relationship_name}</span>
+                <span className="text-gray-400">
+                  {ref.left_table} {ref.operator} {ref.right_table}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/detail/field/FieldScriptReferences.tsx
+++ b/src/components/detail/field/FieldScriptReferences.tsx
@@ -1,0 +1,52 @@
+import { useFieldRefs, useScriptList } from "../../../hooks/useTauriCommand";
+import { useAppStore } from "../../../stores/appStore";
+import { Spinner } from "../../Spinner";
+import { SECTION_HEADER } from "../../../styles/tokens";
+
+interface Props {
+  projectId: number;
+  tableName: string;
+  fieldName: string;
+}
+
+export function FieldScriptReferences({ projectId, tableName, fieldName }: Props) {
+  const { selectElement } = useAppStore();
+  const { data: refs = [], isLoading } = useFieldRefs(projectId, tableName, fieldName);
+  const { data: scripts = [] } = useScriptList(projectId);
+
+  function handleScriptClick(scriptName: string) {
+    const script = scripts.find((s) => s.name === scriptName);
+    if (script) {
+      selectElement({ kind: "script", projectId, id: script.id, name: script.name });
+    }
+  }
+
+  return (
+    <section>
+      <h4 className={SECTION_HEADER}>スクリプト使用箇所</h4>
+      {isLoading ? (
+        <span className="flex items-center gap-1 text-gray-400 text-xs">
+          <Spinner className="w-3 h-3" />
+          読み込み中...
+        </span>
+      ) : refs.length === 0 ? (
+        <p className="text-gray-400 text-xs">
+          このフィールドを参照するスクリプトはありません
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {refs.map((ref) => (
+            <li key={ref.script_id}>
+              <button
+                className="text-blue-600 hover:underline text-left break-all w-full"
+                onClick={() => handleScriptClick(ref.script_name)}
+              >
+                {ref.script_name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/detail/field/FieldStorage.tsx
+++ b/src/components/detail/field/FieldStorage.tsx
@@ -1,0 +1,46 @@
+import type { FieldRow } from "../../../types/ddr";
+import { BADGE_VARIANTS, SECTION_HEADER } from "../../../styles/tokens";
+
+const INDEX_LABEL: Record<string, string> = {
+  All:     "全て",
+  Minimal: "最小",
+  None:    "なし",
+};
+
+interface Props {
+  field: FieldRow;
+}
+
+export function FieldStorage({ field }: Props) {
+  if (!field.index_type && !field.container_storage) return null;
+
+  return (
+    <section>
+      <h4 className={SECTION_HEADER}>ストレージ</h4>
+      <dl className="space-y-1">
+        {field.container_storage && (
+          <div className="flex gap-2">
+            <dt className="text-gray-500 w-24 shrink-0">保存方法</dt>
+            <dd>
+              <span className={BADGE_VARIANTS.purple}>
+                {field.container_storage === "Internal" && "内部格納"}
+                {field.container_storage === "Secure" && "外部格納（セキュア）"}
+                {field.container_storage === "Open" && "外部格納（オープン）"}
+              </span>
+            </dd>
+          </div>
+        )}
+        {field.index_type && (
+          <div className="flex gap-2">
+            <dt className="text-gray-500 w-24 shrink-0">インデックス</dt>
+            <dd>
+              <span className={BADGE_VARIANTS.gray}>
+                {INDEX_LABEL[field.index_type] ?? field.index_type}
+              </span>
+            </dd>
+          </div>
+        )}
+      </dl>
+    </section>
+  );
+}

--- a/src/components/detail/field/FieldValidationRules.tsx
+++ b/src/components/detail/field/FieldValidationRules.tsx
@@ -1,0 +1,85 @@
+import type { FieldRow } from "../../../types/ddr";
+import { BADGE_VARIANTS, CODE_BLOCK, SECTION_HEADER } from "../../../styles/tokens";
+
+interface Props {
+  field: FieldRow;
+}
+
+export function FieldValidationRules({ field }: Props) {
+  const hasValidation =
+    field.val_not_empty ||
+    field.val_unique ||
+    field.val_existing ||
+    field.val_max_length != null ||
+    field.val_value_list ||
+    field.val_calc ||
+    field.val_range_from ||
+    field.val_range_to ||
+    field.val_error_message;
+
+  if (!hasValidation) return null;
+
+  return (
+    <section>
+      <h4 className={SECTION_HEADER}>入力値の制限</h4>
+      <dl className="space-y-1">
+        {(field.val_not_empty || field.val_unique || field.val_existing) && (
+          <div className="flex gap-2 flex-wrap">
+            <dt className="text-gray-500 w-24 shrink-0">種別</dt>
+            <dd className="flex gap-1 flex-wrap">
+              {field.val_not_empty && (
+                <span className={BADGE_VARIANTS.red}>入力必須</span>
+              )}
+              {field.val_unique && (
+                <span className={BADGE_VARIANTS.yellow}>重複不可</span>
+              )}
+              {field.val_existing && (
+                <span className={BADGE_VARIANTS.gray}>既存値のみ</span>
+              )}
+            </dd>
+          </div>
+        )}
+        {field.val_always && (
+          <div className="flex gap-2">
+            <dt className="text-gray-500 w-24 shrink-0">タイミング</dt>
+            <dd>
+              <span className={BADGE_VARIANTS.gray}>常に</span>
+            </dd>
+          </div>
+        )}
+        {field.val_max_length != null && (
+          <div className="flex gap-2">
+            <dt className="text-gray-500 w-24 shrink-0">最大文字数</dt>
+            <dd className="text-gray-900">{field.val_max_length}</dd>
+          </div>
+        )}
+        {field.val_value_list && (
+          <div className="flex gap-2">
+            <dt className="text-gray-500 w-24 shrink-0">値一覧</dt>
+            <dd className="text-gray-900">{field.val_value_list}</dd>
+          </div>
+        )}
+        {(field.val_range_from != null || field.val_range_to != null) && (
+          <div className="flex gap-2">
+            <dt className="text-gray-500 w-24 shrink-0">範囲</dt>
+            <dd className="text-gray-900">
+              {field.val_range_from ?? "?"} 〜 {field.val_range_to ?? "?"}
+            </dd>
+          </div>
+        )}
+        {field.val_calc && (
+          <div className="flex flex-col gap-1">
+            <dt className="text-gray-500">計算式</dt>
+            <dd className={CODE_BLOCK}>{field.val_calc}</dd>
+          </div>
+        )}
+        {field.val_error_message && (
+          <div className="flex gap-2">
+            <dt className="text-gray-500 w-24 shrink-0">エラーメッセージ</dt>
+            <dd className="text-gray-700 break-all">{field.val_error_message}</dd>
+          </div>
+        )}
+      </dl>
+    </section>
+  );
+}

--- a/src/hooks/useSearchFiltering.ts
+++ b/src/hooks/useSearchFiltering.ts
@@ -1,0 +1,33 @@
+import { useState, useMemo } from "react";
+import type { SearchResult } from "../types/ddr";
+
+export interface SearchFilteringResult {
+  activeType: string | null;
+  setActiveType: (type: string | null) => void;
+  countsByType: Record<string, number>;
+  filteredResults: SearchResult[];
+}
+
+export function useSearchFiltering(
+  results: SearchResult[]
+): SearchFilteringResult {
+  const [activeType, setActiveType] = useState<string | null>(null);
+
+  const countsByType = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const r of results) {
+      counts[r.element_type] = (counts[r.element_type] ?? 0) + 1;
+    }
+    return counts;
+  }, [results]);
+
+  const filteredResults = useMemo(
+    () =>
+      activeType
+        ? results.filter((r) => r.element_type === activeType)
+        : results,
+    [results, activeType]
+  );
+
+  return { activeType, setActiveType, countsByType, filteredResults };
+}


### PR DESCRIPTION
## Summary

- `FieldDetail.tsx`（374行）を `src/components/detail/field/` 以下の8サブコンポーネントに分割
  - 純粋表示（field prop のみ）: `FieldBasicProperties` / `FieldAutoEnter` / `FieldValidationRules` / `FieldStorage`
  - IPC参照（各自でフックを保持）: `FieldCalcReferences` / `FieldScriptReferences` / `FieldLayoutReferences` / `FieldRelationshipReferences`
  - `FieldDetail.tsx` 本体は38行のオーケストレーターに削減
- `SearchResults.tsx` のフィルタリングロジックを `useSearchFiltering` フックに抽出（`useMemo` でメモ化）
- 機能変更なし（リファクタリングのみ）

## Test plan

- [ ] `FieldDetail.test.tsx` 10件 PASS
- [ ] `useSearchFiltering` 5件 PASS
- [ ] 全 203 テスト PASS
- [ ] `tsc --noEmit` 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)