### PR TITLE
docs: テストディレクトリ構造・ワークフロー・技術スタック等の残り不整合を修正

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,9 +33,11 @@ filemaker-ddr-viewer/
 │   ├── commands/                   # Tauri IPC コマンド
 │   ├── parser/                     # DDR XML パーサー
 │   ├── db/                         # SQLite データ層
-│   ├── analyzer/                   # 解析エンジン
-│   └── search/                     # tantivy 全文検索（未使用、FTS5 で代替）
-├── tests/fixtures/                 # テスト用 DDR XML サンプル（FM17〜22）
+│   └── analyzer/                   # 解析エンジン
+├── src-tauri/tests/
+│   └── integration_ddr.rs          # 統合テスト
+├── tests/ddr/                      # バージョン別 DDR XML サンプル（FM17〜22、統合テスト用）
+├── tests/fixtures/                 # 小さな単体テスト用 XML（minimal.xml 等）
 └── docs/decisions/                 # 設計判断記録（ADR）
 ```
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@
 | 全文検索 | FTS5（SQLite 組み込み） |
 | データ保存 | rusqlite (SQLite, bundled) |
 | グラフ解析 | petgraph |
-| フロントエンド可視化 | D3.js + dagre-d3 |
+| フロントエンド可視化 | dagre（レイアウト計算）+ ネイティブ SVG |
 | 状態管理 | zustand |
 | サーバー状態 | @tanstack/react-query（Tauri IPC 経由） |
 
@@ -156,9 +156,9 @@ filemaker-ddr-viewer/
 
 ```sql
 CREATE VIRTUAL TABLE search_index USING fts5(
-    project_id UNINDEXED,
-    element_type UNINDEXED,  -- "table" | "field" | "script" | "layout" | ...
-    element_id UNINDEXED,    -- DB auto-increment ID
+    project_id   UNINDEXED,
+    element_type,            -- "table" | "field" | "script" | "layout" | ...（インデックス対象）
+    element_id   UNINDEXED,  -- DB auto-increment ID
     name,                    -- 検索対象: 要素名
     content,                 -- 検索対象: 計算式・ステップ内容・述語等
     tokenize='unicode61'
@@ -208,9 +208,9 @@ CREATE VIRTUAL TABLE search_index USING fts5(
 | `get_project_summary` | analysis.rs | `project_id` | `ProjectSummary` |
 | `get_broken_refs` | analysis.rs | `project_id` | `Vec<BrokenRef>` |
 | `get_report_card` | analysis.rs | `project_id` | `ReportCard` |
-| `resolve_element_by_name` | analysis.rs | `project_id, element_type, name` | `ElementRef` |
+| `resolve_element_by_name` | analysis.rs | `project_id, element_type, name` | `Option<ElementRef>` |
 | `get_upgrade_check` | analysis.rs | `solution_id, check_items` | `Vec<UpgradeHit>` |
-| `search_elements` | search.rs | `project_id, query, limit?` | `Vec<SearchResult>` |
+| `search_elements` | search.rs | `project_id?, solution_id?, query, limit?, contains?` | `Vec<SearchResult>` |
 | `list_tables` | catalog.rs | `project_id` | `Vec<TableRow>` |
 | `list_table_fields` | catalog.rs | `project_id, table_id` | `Vec<FieldRow>` |
 | `list_all_fields` | catalog.rs | `project_id` | `Vec<AllFieldRow>` |
@@ -230,7 +230,7 @@ CREATE VIRTUAL TABLE search_index USING fts5(
 | `get_field_refs` | field_refs.rs | `project_id, table_name, field_name` | `Vec<FieldRefScript>` |
 | `get_field_calc_refs` | field_refs.rs | `project_id, table_name, field_name` | `Vec<FieldCalcRef>` |
 | `get_field_layout_refs` | field_refs.rs | `project_id, table_name, field_name` | `Vec<FieldRefLayout>` |
-| `resolve_layout_field` | field_refs.rs | `project_id, to_name, field_name` | `FieldLocation` |
+| `resolve_layout_field` | field_refs.rs | `project_id, occurrence_name, field_name` | `Option<FieldLocation>` |
 | `get_field_relationship_keys` | field_refs.rs | `project_id, table_name, field_name` | `Vec<FieldRelKeyRef>` |
 | `list_unused_fields` | field_refs.rs | `project_id` | `Vec<UnusedFieldRow>` |
 | `get_layout_ref_debug_info` | field_refs.rs | `project_id, layout_id` | デバッグ情報 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,17 @@ filemaker-ddr-viewer/
 │   └── types/ddr.ts
 │
 ├── tests/
-│   └── fixtures/                   # テスト用DDR XMLサンプル
+│   ├── ddr/                        # バージョン別DDR XMLサンプル（FM17〜22、統合テスト用）
+│   │   ├── 17.0.7.700/
+│   │   ├── 18.0.3.317/
+│   │   ├── 19.6.3.302/
+│   │   ├── 20.3.2.201/
+│   │   ├── 21.1.2.200/
+│   │   └── 22.0.6.601/
+│   └── fixtures/                   # 小さな単体テスト用XML（minimal.xml等）
+│
+├── src-tauri/tests/
+│   └── integration_ddr.rs          # 統合テスト
 │
 ├── package.json
 ├── vite.config.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,11 @@ OSS として公開中: https://github.com/august8/filemaker-ddr-viewer
 - **バックエンド**: Rust（全てのビジネスロジック）
 - **フロントエンド**: React 19 + TypeScript + Vite + TailwindCSS
 - **XML解析**: quick-xml + serde
-- **全文検索**: FTS5（SQLite 組み込み）※ `search/` に tantivy 実装が残っているが未使用
+- **全文検索**: FTS5（SQLite 組み込み）※ Cargo.toml に tantivy が残っているが未使用
 - **データ保存**: rusqlite (SQLite, bundled)
 - **グラフ解析**: petgraph
-- **並列処理**: rayon
-- **フロントエンド可視化**: D3.js + dagre-d3
+- **フロントエンド可視化**: dagre（レイアウト計算）+ ネイティブ SVG
+- **差分表示**: diff2html
 - **状態管理**: zustand
 - **API通信**: @tanstack/react-query（Tauri IPC経由）
 
@@ -175,13 +175,19 @@ filemaker-ddr-viewer/
 **すべての機能追加・変更は以下の手順で進める。**
 
 ```
-1. main から作業ブランチを切る（必須）
+1. プランモードで作業範囲を確認・承認する（必須）
+   - EnterPlanMode を使い、作業対象・確認箇所を全て列挙する
+   - 調査が必要なものはここで全て洗い出し、漏れなく確認する
+   - ユーザーの承認を得てからプランモードを抜ける
+   - 承認なしにファイル編集・実装に進むことは禁止
+
+2. main から作業ブランチを切る（必須）
    - **ファイルに一切触れる前に** ブランチを切ること。編集してからブランチを切るのは禁止
    - ブランチ名は feat/xxx、fix/xxx、refactor/xxx 等
    - ドキュメント修正・小さな変更であっても例外なし
    - main への直接コミット・プッシュは絶対禁止
 
-2. 必要な場合のみ ADR を作成する（docs/decisions/NNNN-slug.md）
+3. 必要な場合のみ ADR を作成する（docs/decisions/NNNN-slug.md）
    - **書くべき条件**（いずれか一つを満たす場合）:
      - 複数の実装案を比較検討した（却下した案がある）
      - 将来「なぜこうなっているのか？」と疑問を持たれそうな非自明な決定
@@ -190,17 +196,17 @@ filemaker-ddr-viewer/
    - ファイル名は `NNNN-slug.md`（連番）。NNNN は docs/decisions/ の最大番号 + 1
    - 外部との設計議論が必要な場合は gh issue create で Issue も立てる
 
-3. テストを書いてから実装する（TDD）
+4. テストを書いてから実装する（TDD）
    - テストコードで仕様を表現する
    - cargo test / npm run test を実行して Green を確認する
 
-4. ADR を作成した場合、実装完了後にステータスを Proposed → Accepted に更新する
+5. ADR を作成した場合、実装完了後にステータスを Proposed → Accepted に更新する
    - docs/decisions/README.md のインデックスも追加する
 
-5. ARCHITECTURE.md を最終確認・更新する
+6. ARCHITECTURE.md を最終確認・更新する
    - 実装で判明した追加の制約・注意点を反映する
 
-6. PR を作成して完了とする
+7. PR を作成して完了とする
    - CI（fmt / clippy / test）が通ることを確認してから PR を作成する
    - main へのマージはユーザーが CI 確認後に実施する
 ```
@@ -225,7 +231,7 @@ filemaker-ddr-viewer/
 - **コンポーネント**: 関数コンポーネント + hooks のみ。class component 禁止
 - **状態管理**: グローバル状態は zustand、サーバー状態は @tanstack/react-query
 - **Tauri IPC**: `invoke()` 呼び出しは必ず hooks/ にラップし、コンポーネントから直接呼ばない
-- **lint**: ESLint + Prettier
+- **型チェック**: `tsc --noEmit`（lefthook で自動チェック）
 
 ## テスト規約（必須）
 
@@ -290,15 +296,18 @@ npm run test -- --coverage    # カバレッジ
 
 ### カバレッジ目標
 
-| レイヤー | 目標 | 重点領域 |
-|---------|------|---------|
-| parser/ | 90%+ | 全XMLセクション、バージョン差異、エッジケース |
-| analyzer/ | 85%+ | 壊れた参照検出、循環参照、コールチェーン |
-| db/ | 80%+ | CRUD操作、マイグレーション |
-| commands/ | 70%+ | IPC入出力の型チェック |
-| stores/ + hooks/ | 80%+ | ロジック層（状態遷移・enabled ガード・スコープ計算） |
-| UIコンポーネント | 60%+ | インタラクション・条件分岐のみ。描画確認テストは不要 |
-| D3/純表示 | 除外 | RelationshipGraphPanel 等は coverage exclude 設定済み |
+フロントエンドの実際の thresholds（`vite.config.ts` で設定）:
+
+| 指標 | 閾値 |
+|------|------|
+| statements | 55% |
+| branches | 48% |
+| functions | 50% |
+| lines | 55% |
+
+coverage exclude 設定済みのファイル:
+- `src/components/detail/RelationshipGraphPanel.tsx`（SVG描画）
+- `src/components/RightPanel.tsx`（純ルーティング）
 
 ### テスト分類
 
@@ -348,4 +357,4 @@ npm run test -- --coverage    # カバレッジ
 - 新しいモジュールを追加したら、必ず `mod.rs` にエクスポートを追加する
 - Tauri IPCコマンドを追加したら、`lib.rs` の `invoke_handler` に登録する
 - フロントエンドの型定義（`types/ddr.ts`）はRust側の型と同期を維持する
-- テストフィクスチャ（DDR XMLサンプル）は `tests/fixtures/` に集約する
+- テストフィクスチャは用途で分けて管理する（`tests/ddr/` にバージョン別DDRサンプル、`tests/fixtures/` に小さな単体テスト用XML）


### PR DESCRIPTION
## Summary

コードとドキュメントの整合性チェックで判明した残り不整合をまとめて修正。

- **テストディレクトリ構造**: `tests/ddr/`（バージョン別）と `tests/fixtures/`（単体テスト用）を正確に記載、`src-tauri/tests/integration_ddr.rs` を追加
- **ワークフロー**: プランモードを step 1 として追加し連番を更新（ファイル編集前に必ず計画・承認を得ることを明文化）
- **技術スタック**: D3.js + dagre-d3 → dagre + ネイティブ SVG、ESLint/Prettier 削除、rayon 削除、diff2html 追加、tantivy 記載を現状に更新
- **カバレッジ目標**: `vite.config.ts` の実際の thresholds に合わせて修正
- **FTS5 スキーマ**: `element_type` から誤った `UNINDEXED` を除去
- **IPC コマンド表**: `search_elements` 引数、`resolve_element_by_name` 戻り値、`resolve_layout_field` 引数・戻り値を正確に修正

## Test plan

- [ ] CLAUDE.md・ARCHITECTURE.md の記述が実際のコード・設定ファイルと一致していることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)