### PR TITLE
fix: ProjectSummary の TypeScript 型を Rust のシリアライズ形式に合わせて修正

### DIFF
--- a/src/__tests__/ProjectSummaryCard.test.tsx
+++ b/src/__tests__/ProjectSummaryCard.test.tsx
@@ -17,9 +17,7 @@ import { useAppStore } from "../stores/appStore";
 const mockSelectElement = vi.fn();
 
 const mockSummary: ProjectSummary = {
-  project_id: 1,
-  name: "My Project",
-  fm_version: "19",
+  project: { id: 1, name: "My Project", file_path: null, fm_version: "19", imported_at: "2024-01-01" },
   table_count: 5,
   field_count: 42,
   script_count: 10,
@@ -28,6 +26,8 @@ const mockSummary: ProjectSummary = {
   relationship_count: 4,
   value_list_count: 3,
   custom_function_count: 2,
+  account_count: 1,
+  privilege_set_count: 2,
 };
 
 beforeEach(() => {

--- a/src/__tests__/StatusBar.test.tsx
+++ b/src/__tests__/StatusBar.test.tsx
@@ -15,9 +15,7 @@ import { useProjectSummary } from "../hooks/useTauriCommand";
 import { useAppStore } from "../stores/appStore";
 
 const mockSummary: ProjectSummary = {
-  project_id: 1,
-  name: "My Project",
-  fm_version: "19",
+  project: { id: 1, name: "My Project", file_path: null, fm_version: "19", imported_at: "2024-01-01" },
   table_count: 5,
   field_count: 42,
   script_count: 10,
@@ -26,6 +24,8 @@ const mockSummary: ProjectSummary = {
   relationship_count: 4,
   value_list_count: 3,
   custom_function_count: 2,
+  account_count: 1,
+  privilege_set_count: 2,
 };
 
 beforeEach(() => {

--- a/src/components/ProjectSummaryCard.tsx
+++ b/src/components/ProjectSummaryCard.tsx
@@ -35,9 +35,9 @@ export function ProjectSummaryCard({ projectId }: Props) {
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-4">
       <div className="flex items-center justify-between mb-3">
-        <h2 className="font-semibold text-gray-800">{summary.name}</h2>
+        <h2 className="font-semibold text-gray-800">{summary.project.name}</h2>
         <span className="text-xs text-gray-400 bg-gray-100 rounded px-2 py-0.5">
-          FM {summary.fm_version}
+          FM {summary.project.fm_version}
         </span>
       </div>
       <div className="grid grid-cols-4 gap-3">

--- a/src/types/ddr.ts
+++ b/src/types/ddr.ts
@@ -26,9 +26,7 @@ export interface SolutionWithProjects {
 }
 
 export interface ProjectSummary {
-  project_id: number;
-  name: string;
-  fm_version: string;
+  project: ProjectRow;
   table_count: number;
   field_count: number;
   script_count: number;
@@ -37,6 +35,8 @@ export interface ProjectSummary {
   relationship_count: number;
   value_list_count: number;
   custom_function_count: number;
+  account_count: number;
+  privilege_set_count: number;
 }
 
 export interface SearchResult {


### PR DESCRIPTION
## Summary

- Rust の `ProjectSummary` は `project: ProjectRow` をネストして serialize するが、TypeScript 型がフラット構造（`project_id`, `name`, `fm_version`）で定義されており、`ProjectSummaryCard.tsx` で `summary.name` / `summary.fm_version` が実行時に `undefined` になるバグがあった
- TypeScript 型を実際の JSON 構造に合わせて修正し、欠けていた `account_count` / `privilege_set_count` も追加

## 変更ファイル

- `src/types/ddr.ts` — `ProjectSummary` を `{ project: ProjectRow, ...counts }` に修正
- `src/components/ProjectSummaryCard.tsx` — `summary.name` → `summary.project.name` 等に修正
- `src/__tests__/ProjectSummaryCard.test.tsx` / `StatusBar.test.tsx` — `mockSummary` を新構造に更新

## Test plan

- [x] `npm run test` 254件パス
- [x] `npx tsc --noEmit` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)