### PR TITLE
ci: PR の Rust ジョブを check と coverage に分割

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  rust:
-    name: Rust
+  rust-check:
+    name: Rust (check)
     runs-on: windows-latest
     defaults:
       run:
@@ -33,14 +33,39 @@ jobs:
         run: |
           rustup target add x86_64-pc-windows-msvc
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
       - name: fmt
         run: cargo fmt --check
 
       - name: clippy
         run: cargo clippy -- -D warnings
+
+      - name: test
+        run: cargo test --lib
+
+  rust-coverage:
+    name: Rust (coverage)
+    runs-on: windows-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    defaults:
+      run:
+        working-directory: src-tauri
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Tauri dependencies
+        run: |
+          rustup target add x86_64-pc-windows-msvc
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: test with coverage
         run: cargo llvm-cov --lib --lcov --output-path lcov.info


### PR DESCRIPTION
## Summary

- PR 時は `cargo test --lib`（インストゥルメントなし）のみ実行
- `cargo llvm-cov` によるカバレッジ収集は **main push 時のみ** 実行
- フロントエンドジョブは変更なし

## 背景

小さな変更でも `cargo llvm-cov` が毎回走るため、PR のフィードバックループが 30 分程度かかっていた。カバレッジは main マージ後に収集すれば実用上問題ないため、PR ブロッカーから分離した。

## Test plan

- [ ] この PR の CI で `rust-check` ジョブのみ実行されることを確認
- [ ] main マージ後に `rust-coverage` ジョブが実行され Codecov が更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)