### PR TITLE
refactor: decode_ddr_bytes を parser モジュールに集約

### DIFF
--- a/src-tauri/src/commands/callchain.rs
+++ b/src-tauri/src/commands/callchain.rs
@@ -52,8 +52,7 @@ pub(crate) fn get_ddr(
     })?;
 
     let bytes = std::fs::read(&path).map_err(CommandError::from)?;
-    let xml = crate::commands::import::decode_ddr_bytes(&bytes)
-        .map_err(|e| CommandError::Parse(format!("デコードエラー: {e}")))?;
+    let xml = crate::parser::decode_ddr_bytes(&bytes).map_err(CommandError::from)?;
 
     let ddr = crate::parser::parse_ddr(&xml)
         .map_err(|e| CommandError::Parse(format!("パースエラー: {e}")))?;

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -50,6 +50,12 @@ impl From<&str> for CommandError {
     }
 }
 
+impl From<crate::parser::ParseError> for CommandError {
+    fn from(e: crate::parser::ParseError) -> Self {
+        CommandError::Parse(e.to_string())
+    }
+}
+
 impl From<crate::db::DbError> for CommandError {
     fn from(e: crate::db::DbError) -> Self {
         match e {

--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -8,43 +8,9 @@ use crate::{
     db::repository::{
         get_project, get_solution_projects, insert_ddr_file, insert_solution, SolutionWithProjects,
     },
-    parser::{normalize_link, parse_ddr, parse_summary},
+    parser::{decode_ddr_bytes, normalize_link, parse_ddr, parse_summary},
     AppState,
 };
-
-// ---------------------------------------------------------------------------
-// ビジネスロジック（テスト可能な部分を分離）
-// ---------------------------------------------------------------------------
-
-/// DDR ファイルのバイト列を UTF-8 文字列にデコードする。
-///
-/// FileMaker DDR は UTF-16 LE BOM (`\xFF\xFE`) または UTF-8 で出力される。
-/// UTF-16 BE BOM (`\xFE\xFF`) および UTF-8 BOM (`\xEF\xBB\xBF`) にも対応。
-pub(crate) fn decode_ddr_bytes(bytes: &[u8]) -> Result<String, String> {
-    if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE {
-        // UTF-16 LE
-        let words: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
-            .map(|c| u16::from_le_bytes([c[0], c[1]]))
-            .collect();
-        String::from_utf16(&words)
-            .or_else(|_| Ok::<String, String>(String::from_utf16_lossy(&words)))
-    } else if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
-        // UTF-16 BE
-        let words: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
-            .map(|c| u16::from_be_bytes([c[0], c[1]]))
-            .collect();
-        String::from_utf16(&words)
-            .or_else(|_| Ok::<String, String>(String::from_utf16_lossy(&words)))
-    } else if bytes.len() >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF {
-        // UTF-8 BOM
-        String::from_utf8(bytes[3..].to_vec()).map_err(|e| format!("UTF-8 デコードエラー: {e}"))
-    } else {
-        // UTF-8 (BOM なし)
-        String::from_utf8(bytes.to_vec()).map_err(|e| format!("UTF-8 デコードエラー: {e}"))
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Tauri コマンド
@@ -282,70 +248,6 @@ mod tests {
         assert!(xml_result.is_ok());
         let parse_result = parse_summary(&xml_result.unwrap());
         assert!(parse_result.is_err());
-    }
-
-    #[test]
-    fn decode_ddr_bytes_utf8() {
-        let xml = b"<?xml version=\"1.0\"?><root/>";
-        let result = decode_ddr_bytes(xml).unwrap();
-        assert!(result.contains("<root/>"));
-    }
-
-    #[test]
-    fn decode_ddr_bytes_utf16_le_bom() {
-        // UTF-16 LE BOM + "AB"
-        let mut bytes: Vec<u8> = vec![0xFF, 0xFE];
-        for ch in "AB".encode_utf16() {
-            bytes.extend_from_slice(&ch.to_le_bytes());
-        }
-        let result = decode_ddr_bytes(&bytes).unwrap();
-        assert_eq!(result, "AB");
-    }
-
-    #[test]
-    fn decode_ddr_bytes_utf8_bom() {
-        let mut bytes = vec![0xEF, 0xBB, 0xBF];
-        bytes.extend_from_slice(b"hello");
-        let result = decode_ddr_bytes(&bytes).unwrap();
-        assert_eq!(result, "hello");
-    }
-
-    #[test]
-    fn decode_ddr_bytes_utf16_le_invalid_surrogate_falls_back_lossy() {
-        // UTF-16 LE BOM + 孤立サロゲート 0xD800 + 'A'
-        // 0xD800 はサロゲートペアの前半のみで不正な UTF-16
-        let mut bytes: Vec<u8> = vec![0xFF, 0xFE];
-        bytes.extend_from_slice(&0xD800_u16.to_le_bytes()); // 孤立サロゲート
-        bytes.extend_from_slice(&('A' as u16).to_le_bytes());
-        // 修正前: from_utf16() がエラーを返すため Err になる
-        // 修正後: from_utf16_lossy() にフォールバックして Ok (U+FFFD + 'A') になる
-        let result = decode_ddr_bytes(&bytes);
-        assert!(
-            result.is_ok(),
-            "不正UTF-16でもlossyフォールバックでOkを返すこと"
-        );
-        let s = result.unwrap();
-        assert!(s.contains('A'), "有効な文字はそのまま含まれること");
-        assert!(
-            s.contains('\u{FFFD}'),
-            "不正サロゲートはU+FFDDに置換されること"
-        );
-    }
-
-    #[test]
-    fn decode_ddr_bytes_utf16_be_invalid_surrogate_falls_back_lossy() {
-        // UTF-16 BE BOM + 孤立サロゲート 0xDC00 + 'B'
-        let mut bytes: Vec<u8> = vec![0xFE, 0xFF];
-        bytes.extend_from_slice(&0xDC00_u16.to_be_bytes()); // 孤立サロゲート（後半のみ）
-        bytes.extend_from_slice(&('B' as u16).to_be_bytes());
-        let result = decode_ddr_bytes(&bytes);
-        assert!(
-            result.is_ok(),
-            "BE版でも不正UTF-16でlossyフォールバックすること"
-        );
-        let s = result.unwrap();
-        assert!(s.contains('B'));
-        assert!(s.contains('\u{FFFD}'));
     }
 
     #[test]

--- a/src-tauri/src/parser/mod.rs
+++ b/src-tauri/src/parser/mod.rs
@@ -65,6 +65,42 @@ pub use summary_parser::{normalize_link, parse_summary, SummaryEntry};
 pub use version::{FmVersion, VersionAdapter};
 
 // ---------------------------------------------------------------------------
+// DDR バイト列デコード
+// ---------------------------------------------------------------------------
+
+/// DDR ファイルのバイト列を UTF-8 文字列にデコードする。
+///
+/// FileMaker DDR は UTF-16 LE BOM (`\xFF\xFE`) または UTF-8 で出力される。
+/// UTF-16 BE BOM (`\xFE\xFF`) および UTF-8 BOM (`\xEF\xBB\xBF`) にも対応。
+pub fn decode_ddr_bytes(bytes: &[u8]) -> Result<String, ParseError> {
+    if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE {
+        // UTF-16 LE
+        let words: Vec<u16> = bytes[2..]
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        String::from_utf16(&words)
+            .or_else(|_| Ok::<String, ParseError>(String::from_utf16_lossy(&words)))
+    } else if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
+        // UTF-16 BE
+        let words: Vec<u16> = bytes[2..]
+            .chunks_exact(2)
+            .map(|c| u16::from_be_bytes([c[0], c[1]]))
+            .collect();
+        String::from_utf16(&words)
+            .or_else(|_| Ok::<String, ParseError>(String::from_utf16_lossy(&words)))
+    } else if bytes.len() >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF {
+        // UTF-8 BOM
+        String::from_utf8(bytes[3..].to_vec())
+            .map_err(|e| ParseError::InvalidValue(format!("UTF-8 デコードエラー: {e}")))
+    } else {
+        // UTF-8 (BOM なし)
+        String::from_utf8(bytes.to_vec())
+            .map_err(|e| ParseError::InvalidValue(format!("UTF-8 デコードエラー: {e}")))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -89,5 +125,66 @@ mod tests {
     fn parse_error_display_invalid_version() {
         let e = ParseError::InvalidVersion("bad".to_owned());
         assert!(e.to_string().contains("bad"));
+    }
+
+    #[test]
+    fn decode_ddr_bytes_utf8() {
+        let xml = b"<?xml version=\"1.0\"?><root/>";
+        let result = decode_ddr_bytes(xml).unwrap();
+        assert!(result.contains("<root/>"));
+    }
+
+    #[test]
+    fn decode_ddr_bytes_utf16_le_bom() {
+        // UTF-16 LE BOM + "AB"
+        let mut bytes: Vec<u8> = vec![0xFF, 0xFE];
+        for ch in "AB".encode_utf16() {
+            bytes.extend_from_slice(&ch.to_le_bytes());
+        }
+        let result = decode_ddr_bytes(&bytes).unwrap();
+        assert_eq!(result, "AB");
+    }
+
+    #[test]
+    fn decode_ddr_bytes_utf8_bom() {
+        let mut bytes = vec![0xEF, 0xBB, 0xBF];
+        bytes.extend_from_slice(b"hello");
+        let result = decode_ddr_bytes(&bytes).unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn decode_ddr_bytes_utf16_le_invalid_surrogate_falls_back_lossy() {
+        // UTF-16 LE BOM + 孤立サロゲート 0xD800 + 'A'
+        let mut bytes: Vec<u8> = vec![0xFF, 0xFE];
+        bytes.extend_from_slice(&0xD800_u16.to_le_bytes());
+        bytes.extend_from_slice(&('A' as u16).to_le_bytes());
+        let result = decode_ddr_bytes(&bytes);
+        assert!(
+            result.is_ok(),
+            "不正UTF-16でもlossyフォールバックでOkを返すこと"
+        );
+        let s = result.unwrap();
+        assert!(s.contains('A'), "有効な文字はそのまま含まれること");
+        assert!(
+            s.contains('\u{FFFD}'),
+            "不正サロゲートはU+FFDDに置換されること"
+        );
+    }
+
+    #[test]
+    fn decode_ddr_bytes_utf16_be_invalid_surrogate_falls_back_lossy() {
+        // UTF-16 BE BOM + 孤立サロゲート 0xDC00 + 'B'
+        let mut bytes: Vec<u8> = vec![0xFE, 0xFF];
+        bytes.extend_from_slice(&0xDC00_u16.to_be_bytes());
+        bytes.extend_from_slice(&('B' as u16).to_be_bytes());
+        let result = decode_ddr_bytes(&bytes);
+        assert!(
+            result.is_ok(),
+            "BE版でも不正UTF-16でlossyフォールバックすること"
+        );
+        let s = result.unwrap();
+        assert!(s.contains('B'));
+        assert!(s.contains('\u{FFFD}'));
     }
 }

--- a/src-tauri/tests/integration_ddr.rs
+++ b/src-tauri/tests/integration_ddr.rs
@@ -4,31 +4,8 @@
 //! パーサーが FM17〜22 の実出力に対して正常に動作することを検証する。
 //! テーブルなしファイルのパースも検証する。
 
-use filemaker_ddr_viewer_lib::parser::parse_ddr;
+use filemaker_ddr_viewer_lib::parser::{decode_ddr_bytes, parse_ddr};
 use rstest::rstest;
-
-/// UTF-16 LE/BE ファイルを文字列にデコードする。
-/// `commands/import.rs` の `decode_ddr_bytes` と同じロジック。
-fn decode_ddr_bytes(bytes: &[u8]) -> String {
-    // UTF-16 LE BOM
-    if bytes.starts_with(&[0xFF, 0xFE]) {
-        let words: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
-            .map(|c| u16::from_le_bytes([c[0], c[1]]))
-            .collect();
-        return String::from_utf16_lossy(&words);
-    }
-    // UTF-16 BE BOM
-    if bytes.starts_with(&[0xFE, 0xFF]) {
-        let words: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
-            .map(|c| u16::from_be_bytes([c[0], c[1]]))
-            .collect();
-        return String::from_utf16_lossy(&words);
-    }
-    // UTF-8 (フォールバック)
-    String::from_utf8_lossy(bytes).into_owned()
-}
 
 #[rstest]
 #[case("17.0.7.700")]
@@ -40,7 +17,7 @@ fn decode_ddr_bytes(bytes: &[u8]) -> String {
 fn parse_real_ddr_succeeds(#[case] version: &str) {
     let path = format!("../tests/ddr/{version}/BaseFile_fmp12.xml");
     let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("{path}: {e}"));
-    let xml = decode_ddr_bytes(&bytes);
+    let xml = decode_ddr_bytes(&bytes).expect("decode failed");
     let result = parse_ddr(&xml);
     assert!(
         result.is_ok(),
@@ -59,7 +36,7 @@ fn parse_real_ddr_succeeds(#[case] version: &str) {
 fn parse_real_ddr_version_detected(#[case] version: &str, #[case] expected_major: u32) {
     let path = format!("../tests/ddr/{version}/BaseFile_fmp12.xml");
     let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("{path}: {e}"));
-    let xml = decode_ddr_bytes(&bytes);
+    let xml = decode_ddr_bytes(&bytes).expect("decode failed");
     let ddr = parse_ddr(&xml).unwrap_or_else(|e| panic!("FM{version} パース失敗: {e}"));
     assert_eq!(
         ddr.fm_version.major, expected_major,
@@ -77,7 +54,7 @@ fn parse_real_ddr_version_detected(#[case] version: &str, #[case] expected_major
 fn parse_real_ddr_has_tables_and_fields(#[case] version: &str) {
     let path = format!("../tests/ddr/{version}/BaseFile_fmp12.xml");
     let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("{path}: {e}"));
-    let xml = decode_ddr_bytes(&bytes);
+    let xml = decode_ddr_bytes(&bytes).expect("decode failed");
     let ddr = parse_ddr(&xml).unwrap_or_else(|e| panic!("FM{version} パース失敗: {e}"));
     assert!(!ddr.tables.is_empty(), "FM{version}: テーブルが0件");
     let total_fields: usize = ddr.tables.iter().map(|t| t.fields.len()).sum();
@@ -88,7 +65,7 @@ fn parse_real_ddr_has_tables_and_fields(#[case] version: &str) {
 fn parse_no_table_ddr_succeeds() {
     let path = "../tests/ddr/NoTableDDR/NoTableFile_fmp12.xml";
     let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("{path}: {e}"));
-    let xml = decode_ddr_bytes(&bytes);
+    let xml = decode_ddr_bytes(&bytes).expect("decode failed");
     let ddr = parse_ddr(&xml).unwrap_or_else(|e| panic!("テーブルなし DDR のパース失敗: {e}"));
     assert!(
         ddr.tables.is_empty(),


### PR DESCRIPTION
## 概要

`decode_ddr_bytes` の重複実装を `parser::decode_ddr_bytes` に一本化。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `src-tauri/src/parser/mod.rs` | `pub fn decode_ddr_bytes` を追加、デコード専用テスト 5 件を移動 |
| `src-tauri/src/commands/error.rs` | `impl From<ParseError> for CommandError` を追加 |
| `src-tauri/src/commands/import.rs` | ローカル定義を削除、`parser::decode_ddr_bytes` を使用 |
| `src-tauri/src/commands/callchain.rs` | `crate::commands::import::decode_ddr_bytes` → `crate::parser::decode_ddr_bytes` |
| `src-tauri/tests/integration_ddr.rs` | ローカルコピーを削除、`filemaker_ddr_viewer_lib::parser::decode_ddr_bytes` を使用 |

## 主な変更点

- 戻り値型を `Result<String, String>` → `Result<String, ParseError>` に統一
- `ParseError::InvalidValue` でエンコーディングエラーを表現
- `From<ParseError> for CommandError` を追加したことで、`?` での変換が可能に

## 検証

- `cargo test --lib` → **359 tests passed**
- `cargo test --test integration_ddr` → **19 tests passed**
- fmt / clippy クリーン（lefthook 通過）

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)