### PR TITLE
feat: CommandError 日本語化 + callchain テスト追加

### DIFF
--- a/src-tauri/src/commands/callchain.rs
+++ b/src-tauri/src/commands/callchain.rs
@@ -162,4 +162,54 @@ mod tests {
         let orphans = crate::analyzer::orphans::find_orphan_scripts(&ddr);
         assert!(orphans.len() <= ddr.scripts.len());
     }
+
+    #[test]
+    fn find_callers_returns_empty_for_root_script() {
+        // minimal.xml: Script id=1 "Hello World" は誰にも呼ばれていない
+        let ddr = setup_ddr();
+        let callers = find_callers(&ddr, ScriptId(1));
+        assert!(
+            callers.is_empty(),
+            "呼び出し元がないスクリプトの呼び出し元は空であること"
+        );
+    }
+
+    #[test]
+    fn find_callers_returns_empty_for_nonexistent_script() {
+        // 存在しないスクリプト ID の呼び出し元は空
+        let ddr = setup_ddr();
+        let callers = find_callers(&ddr, ScriptId(99999));
+        assert!(
+            callers.is_empty(),
+            "存在しない ID の呼び出し元は空であること"
+        );
+    }
+
+    #[test]
+    fn call_chain_leaf_script_has_no_children() {
+        // minimal.xml: "Hello World" は Perform Script で "Another Script" を参照しているが、
+        // "Another Script" はカタログに定義されていないため子ノードは 0 件になる
+        let ddr = setup_ddr();
+        let node = build_call_chain(&ddr, ScriptId(1), None).unwrap();
+        assert_eq!(node.depth, 0, "ルートノードの depth は 0 であること");
+        assert!(
+            node.children.is_empty(),
+            "カタログ未定義の参照先は子ノードに含まれないこと"
+        );
+    }
+
+    #[test]
+    fn orphan_scripts_are_not_called_by_anyone() {
+        // 孤立スクリプトは find_callers で 0 件になること
+        let ddr = setup_ddr();
+        let orphans = crate::analyzer::orphans::find_orphan_scripts(&ddr);
+        for orphan in &orphans {
+            let callers = find_callers(&ddr, ScriptId(orphan.script_id));
+            assert!(
+                callers.is_empty(),
+                "孤立スクリプト {} の呼び出し元は存在しないこと",
+                orphan.script_name
+            );
+        }
+    }
 }

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -10,19 +10,19 @@ use serde::Serialize;
 #[derive(Debug, Serialize, thiserror::Error)]
 #[serde(tag = "kind", content = "message")]
 pub enum CommandError {
-    #[error("Database error: {0}")]
+    #[error("データベースエラー: {0}")]
     Database(String),
 
-    #[error("Parse error: {0}")]
+    #[error("パースエラー: {0}")]
     Parse(String),
 
-    #[error("Not found: {0}")]
+    #[error("見つかりません: {0}")]
     NotFound(String),
 
-    #[error("IO error: {0}")]
+    #[error("IOエラー: {0}")]
     Io(String),
 
-    #[error("Internal error: {0}")]
+    #[error("内部エラー: {0}")]
     Internal(String),
 }
 
@@ -74,7 +74,7 @@ mod tests {
     fn from_string_maps_to_internal() {
         let err = CommandError::from("something went wrong".to_string());
         assert!(matches!(err, CommandError::Internal(_)));
-        assert_eq!(err.to_string(), "Internal error: something went wrong");
+        assert_eq!(err.to_string(), "内部エラー: something went wrong");
     }
 
     #[test]
@@ -88,7 +88,7 @@ mod tests {
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
         let err = CommandError::from(io_err);
         assert!(matches!(err, CommandError::Io(_)));
-        assert!(err.to_string().contains("IO error"));
+        assert!(err.to_string().contains("IOエラー"));
     }
 
     #[test]
@@ -96,7 +96,7 @@ mod tests {
         let db_err = rusqlite::Error::QueryReturnedNoRows;
         let err = CommandError::from(db_err);
         assert!(matches!(err, CommandError::Database(_)));
-        assert!(err.to_string().contains("Database error"));
+        assert!(err.to_string().contains("データベースエラー"));
     }
 
     #[test]
@@ -134,23 +134,23 @@ mod tests {
     fn display_messages_are_correct() {
         assert_eq!(
             CommandError::Database("db err".to_string()).to_string(),
-            "Database error: db err"
+            "データベースエラー: db err"
         );
         assert_eq!(
             CommandError::Parse("parse err".to_string()).to_string(),
-            "Parse error: parse err"
+            "パースエラー: parse err"
         );
         assert_eq!(
             CommandError::NotFound("not found".to_string()).to_string(),
-            "Not found: not found"
+            "見つかりません: not found"
         );
         assert_eq!(
             CommandError::Io("io err".to_string()).to_string(),
-            "IO error: io err"
+            "IOエラー: io err"
         );
         assert_eq!(
             CommandError::Internal("internal".to_string()).to_string(),
-            "Internal error: internal"
+            "内部エラー: internal"
         );
     }
 }


### PR DESCRIPTION
## 概要

#28 と #29 を同一 PR で対応。日本語化しながらテストも日本語期待値で書ける状態にした。

## 変更内容

### #28 — CommandError 日本語化（`src-tauri/src/commands/error.rs`）

| 変更前 | 変更後 |
|--------|--------|
| `"Database error: {0}"` | `"データベースエラー: {0}"` |
| `"Parse error: {0}"` | `"パースエラー: {0}"` |
| `"Not found: {0}"` | `"見つかりません: {0}"` |
| `"IO error: {0}"` | `"IOエラー: {0}"` |
| `"Internal error: {0}"` | `"内部エラー: {0}"` |

テストの期待値文字列も同期して更新。

### #29 — callchain テスト追加（`src-tauri/src/commands/callchain.rs`）

既存 3 件 → 7 件に増加。追加テスト:

| テスト名 | 検証内容 |
|---------|---------|
| `find_callers_returns_empty_for_root_script` | 誰にも呼ばれないスクリプトの呼び出し元は空 |
| `find_callers_returns_empty_for_nonexistent_script` | 存在しない ID の呼び出し元は空 |
| `call_chain_leaf_script_has_no_children` | カタログ未定義の参照先は子ノードに含まれない |
| `orphan_scripts_are_not_called_by_anyone` | 孤立スクリプトは必ず呼び出し元ゼロ |

#### 調査で判明した補足

issue #29 作成時点では catalog/analysis/diff/field_refs のテストが0件だったが、
現在はそれぞれ 19/22/14/32 件と十分なカバレッジが確保されていた。
callchain.rs のみ 3 件と少なかったため、ここに注力。

## 検証

- `cargo test --lib` → **363 tests passed**（359 → +4）
- fmt / clippy クリーン（lefthook 通過）

Closes #28
Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)