### PR TITLE
refactor: lock_db ヘルパーで DB ロック取得を一箇所に集約

### DIFF
--- a/src-tauri/src/commands/analysis.rs
+++ b/src-tauri/src/commands/analysis.rs
@@ -1,4 +1,4 @@
-//! プロジェクト管理・サマリー取得コマンド。
+﻿//! プロジェクト管理・サマリー取得コマンド。
 
 use rusqlite::{params, OptionalExtension as _};
 use serde::{Deserialize, Serialize};
@@ -94,10 +94,7 @@ pub(crate) fn build_project_summary(
 pub async fn list_solutions(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<SolutionRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_solutions(&db).map_err(CommandError::from)
 }
 
@@ -107,10 +104,7 @@ pub async fn get_solution_projects(
     state: tauri::State<'_, AppState>,
     solution_id: i64,
 ) -> Result<Vec<ProjectRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     crate::db::repository::get_solution_projects(&db, solution_id).map_err(CommandError::from)
 }
 
@@ -120,10 +114,7 @@ pub async fn delete_solution(
     state: tauri::State<'_, AppState>,
     solution_id: i64,
 ) -> Result<(), CommandError> {
-    let mut db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let mut db = super::lock_db(&state)?;
     db_delete_solution(&mut db, solution_id).map_err(CommandError::from)
 }
 
@@ -132,10 +123,7 @@ pub async fn delete_solution(
 pub async fn list_projects(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<ProjectRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_projects(&db).map_err(CommandError::from)
 }
 
@@ -145,10 +133,7 @@ pub async fn delete_project(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<(), CommandError> {
-    let mut db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let mut db = super::lock_db(&state)?;
     db_delete_project(&mut db, project_id).map_err(CommandError::from)
 }
 
@@ -158,10 +143,7 @@ pub async fn get_project_summary(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<ProjectSummary, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     build_project_summary(&db, project_id)
 }
 
@@ -193,10 +175,7 @@ pub async fn resolve_element_by_name(
     element_type: String,
     name: String,
 ) -> Result<Option<ElementRef>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     resolve_element_by_name_inner(&db.conn, project_id, &element_type, &name)
         .map_err(CommandError::from)
 }
@@ -236,10 +215,7 @@ pub async fn get_upgrade_check(
     solution_id: i64,
     check_items: Vec<CheckItemConfig>,
 ) -> Result<Vec<UpgradeHit>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     run_upgrade_check(&db, solution_id, &check_items).map_err(CommandError::from)
 }
 

--- a/src-tauri/src/commands/callchain.rs
+++ b/src-tauri/src/commands/callchain.rs
@@ -1,4 +1,4 @@
-//! スクリプト呼び出しチェーン解析コマンド。
+﻿//! スクリプト呼び出しチェーン解析コマンド。
 
 use std::sync::Arc;
 
@@ -38,10 +38,7 @@ pub(crate) fn get_ddr(
 
     // キャッシュにない場合はファイルパスから再読み込み
     let file_path = {
-        let db = state
-            .db
-            .lock()
-            .map_err(|e| CommandError::Internal(e.to_string()))?;
+        let db = super::lock_db(state)?;
         crate::db::repository::get_project(&db, project_id)
             .map_err(CommandError::from)?
             .file_path

--- a/src-tauri/src/commands/catalog.rs
+++ b/src-tauri/src/commands/catalog.rs
@@ -1,4 +1,4 @@
-//! エンティティ一覧取得コマンド。
+﻿//! エンティティ一覧取得コマンド。
 
 use rusqlite::params;
 use serde::{Deserialize, Serialize};
@@ -55,10 +55,7 @@ pub async fn list_tables(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<TableRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_tables(&db, project_id).map_err(CommandError::from)
 }
 
@@ -68,10 +65,7 @@ pub async fn list_all_fields(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<AllFieldRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     list_all_fields_inner(&db, project_id).map_err(CommandError::from)
 }
 
@@ -115,10 +109,7 @@ pub async fn list_table_fields(
     project_id: i64,
     table_id: i64,
 ) -> Result<Vec<FieldRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_table_fields(&db, project_id, table_id).map_err(CommandError::from)
 }
 
@@ -128,10 +119,7 @@ pub async fn list_scripts(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<ScriptRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_scripts(&db, project_id).map_err(CommandError::from)
 }
 
@@ -141,10 +129,7 @@ pub async fn list_script_steps(
     state: tauri::State<'_, AppState>,
     script_id: i64,
 ) -> Result<Vec<ScriptStepRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_script_steps(&db, script_id).map_err(CommandError::from)
 }
 
@@ -154,10 +139,7 @@ pub async fn list_layouts(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<LayoutRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_layouts(&db, project_id).map_err(CommandError::from)
 }
 
@@ -167,10 +149,7 @@ pub async fn list_layout_triggers(
     state: tauri::State<'_, AppState>,
     layout_id: i64,
 ) -> Result<Vec<TriggerRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_layout_triggers(&db, layout_id).map_err(CommandError::from)
 }
 
@@ -180,10 +159,7 @@ pub async fn list_layout_objects(
     state: tauri::State<'_, AppState>,
     layout_id: i64,
 ) -> Result<Vec<LayoutObjectRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_layout_objects(&db, layout_id).map_err(CommandError::from)
 }
 
@@ -193,10 +169,7 @@ pub async fn list_layout_object_conditions(
     state: tauri::State<'_, AppState>,
     object_id: i64,
 ) -> Result<Vec<ConditionRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_layout_object_conditions(&db, object_id).map_err(CommandError::from)
 }
 
@@ -206,10 +179,7 @@ pub async fn list_value_lists(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<ValueListRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_value_lists(&db, project_id).map_err(CommandError::from)
 }
 
@@ -219,10 +189,7 @@ pub async fn list_value_list_items(
     state: tauri::State<'_, AppState>,
     value_list_id: i64,
 ) -> Result<Vec<String>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_value_list_items(&db, value_list_id).map_err(CommandError::from)
 }
 
@@ -232,10 +199,7 @@ pub async fn list_custom_functions(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<CustomFunctionRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_custom_functions(&db, project_id).map_err(CommandError::from)
 }
 
@@ -245,10 +209,7 @@ pub async fn list_table_occurrences(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<TableOccurrenceRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_table_occurrences(&db, project_id).map_err(CommandError::from)
 }
 
@@ -258,10 +219,7 @@ pub async fn list_relationships(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<RelationshipRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_relationships(&db, project_id).map_err(CommandError::from)
 }
 
@@ -271,10 +229,7 @@ pub async fn list_accounts(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<AccountRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_accounts(&db, project_id).map_err(CommandError::from)
 }
 
@@ -284,10 +239,7 @@ pub async fn list_privilege_sets(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<PrivilegeSetRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     db_list_privilege_sets(&db, project_id).map_err(CommandError::from)
 }
 

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -1,4 +1,4 @@
-//! DDR 差分比較コマンド。
+﻿//! DDR 差分比較コマンド。
 
 use crate::{
     analyzer::diff_engine::{diff_ddr, DiffItem, DiffKind, DiffResult},
@@ -25,10 +25,7 @@ pub struct ProjectWithSolution {
 pub async fn list_all_projects(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<ProjectWithSolution>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     list_all_projects_inner(&db.conn).map_err(CommandError::from)
 }
 
@@ -79,17 +76,11 @@ pub async fn compare_solutions(
     solution_id_b: i64,
 ) -> Result<DiffResult, CommandError> {
     let projects_a = {
-        let db = state
-            .db
-            .lock()
-            .map_err(|e| CommandError::Internal(e.to_string()))?;
+        let db = super::lock_db(&state)?;
         get_solution_projects(&db, solution_id_a).map_err(CommandError::from)?
     };
     let projects_b = {
-        let db = state
-            .db
-            .lock()
-            .map_err(|e| CommandError::Internal(e.to_string()))?;
+        let db = super::lock_db(&state)?;
         get_solution_projects(&db, solution_id_b).map_err(CommandError::from)?
     };
 

--- a/src-tauri/src/commands/field_refs.rs
+++ b/src-tauri/src/commands/field_refs.rs
@@ -1,4 +1,4 @@
-//! フィールド参照解析コマンド。
+﻿//! フィールド参照解析コマンド。
 
 use rusqlite::{params, OptionalExtension as _};
 use serde::{Deserialize, Serialize};
@@ -88,10 +88,7 @@ pub async fn get_field_refs(
     if table_name.is_empty() || field_name.is_empty() {
         return Ok(vec![]);
     }
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
 
     // 1. ベーステーブルに紐づく全オカレンス名を取得
     let occ_names =
@@ -152,10 +149,7 @@ pub async fn get_field_calc_refs(
     if table_name.is_empty() || field_name.is_empty() {
         return Ok(vec![]);
     }
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
 
     // 1. ベーステーブルに紐づく全オカレンス名を取得
     let occ_names =
@@ -221,10 +215,7 @@ pub async fn get_field_layout_refs(
     if table_name.is_empty() || field_name.is_empty() {
         return Ok(vec![]);
     }
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     get_field_layout_refs_inner(&db.conn, project_id, &table_name, &field_name)
         .map_err(CommandError::from)
 }
@@ -237,10 +228,7 @@ pub async fn resolve_layout_field(
     occurrence_name: String,
     field_name: String,
 ) -> Result<Option<FieldLocation>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     resolve_layout_field_inner(&db.conn, project_id, &occurrence_name, &field_name)
         .map_err(CommandError::from)
 }
@@ -259,10 +247,7 @@ pub async fn get_field_relationship_keys(
     if table_name.is_empty() || field_name.is_empty() {
         return Ok(vec![]);
     }
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     get_field_relationship_keys_inner(&db.conn, project_id, &table_name, &field_name)
         .map_err(CommandError::from)
 }
@@ -281,10 +266,7 @@ pub async fn list_unused_fields(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<UnusedFieldRow>, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     list_unused_fields_inner(&db.conn, project_id).map_err(CommandError::from)
 }
 
@@ -529,10 +511,7 @@ pub async fn get_layout_ref_debug_info(
     state: tauri::State<'_, AppState>,
     project_id: i64,
 ) -> Result<LayoutRefDebugInfo, CommandError> {
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     get_layout_ref_debug_info_inner(&db.conn, project_id).map_err(CommandError::from)
 }
 

--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -1,4 +1,4 @@
-//! DDR ファイルのインポートコマンド。
+﻿//! DDR ファイルのインポートコマンド。
 
 use std::path::Path;
 use std::sync::Arc;
@@ -54,10 +54,7 @@ pub async fn import_solution(
 
     // 5. DB に solution を作成
     let solution_id = {
-        let mut db = state
-            .db
-            .lock()
-            .map_err(|e| CommandError::Internal(e.to_string()))?;
+        let mut db = super::lock_db(&state)?;
         insert_solution(&mut db, &solution_name, Some(&summary_path))
             .map_err(|e| CommandError::Database(format!("DB挿入エラー: {e}")))?
     };
@@ -83,10 +80,7 @@ pub async fn import_solution(
         let ddr_arc = Arc::new(ddr);
 
         let project_id = {
-            let mut db = state
-                .db
-                .lock()
-                .map_err(|e| CommandError::Internal(e.to_string()))?;
+            let mut db = super::lock_db(&state)?;
             insert_ddr_file(&mut db, &ddr_arc, solution_id, Some(&detail_path_str))
                 .map_err(|e| CommandError::Database(format!("DB挿入エラー ({file_name}): {e}")))?
         };
@@ -102,10 +96,7 @@ pub async fn import_solution(
     }
 
     // 7. solution + projects を取得して返す
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     let solution =
         crate::db::repository::get_solution(&db, solution_id).map_err(CommandError::from)?;
     let projects = get_solution_projects(&db, solution_id).map_err(CommandError::from)?;
@@ -134,10 +125,7 @@ pub async fn import_ddr(
 
     // 3. solution + project を DB に保存
     let (_solution_id, project_id) = {
-        let mut db = state
-            .db
-            .lock()
-            .map_err(|e| CommandError::Internal(e.to_string()))?;
+        let mut db = super::lock_db(&state)?;
         let sid = insert_solution(&mut db, &ddr_arc.file_name, Some(&file_path))
             .map_err(|e| CommandError::Database(format!("DB挿入エラー: {e}")))?;
         let pid = insert_ddr_file(&mut db, &ddr_arc, sid, Some(&file_path))
@@ -155,10 +143,7 @@ pub async fn import_ddr(
     }
 
     // 5. ProjectRow を返す
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
     get_project(&db, project_id).map_err(CommandError::from)
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -13,3 +13,17 @@ pub mod import;
 pub mod search;
 
 pub use error::CommandError;
+
+/// `state.db` のロックを取得する共通ヘルパー。
+///
+/// 全コマンドで繰り返されていた
+/// `state.db.lock().map_err(|e| CommandError::Internal(e.to_string()))?`
+/// を一箇所に集約する。
+pub(crate) fn lock_db(
+    state: &crate::AppState,
+) -> Result<std::sync::MutexGuard<'_, crate::db::Database>, CommandError> {
+    state
+        .db
+        .lock()
+        .map_err(|e| CommandError::Internal(e.to_string()))
+}

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -1,4 +1,4 @@
-//! FTS5 全文検索コマンド。
+﻿//! FTS5 全文検索コマンド。
 
 use crate::{
     commands::CommandError,
@@ -34,10 +34,7 @@ pub async fn search_elements(
         Some(0) | None => -1,
         Some(n) => n as i64,
     };
-    let db = state
-        .db
-        .lock()
-        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    let db = super::lock_db(&state)?;
 
     if contains == Some(true) {
         search_contains(&db, project_id, solution_id, &query, sql_limit).map_err(CommandError::from)


### PR DESCRIPTION
## Summary

- 全コマンドで重複していた `state.db.lock().map_err(|e| CommandError::Internal(e.to_string()))?` を `commands::lock_db()` に抽出
- `analysis`, `callchain`, `catalog`, `diff`, `field_refs`, `import`, `search` の7ファイルから重複コードを除去
- 8ファイルで +62 / -171 行（実質109行削減）

## Test plan

- [x] `cargo fmt --check` パス
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo test` 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)