### PR TITLE
docs: update hooks references after useTauriCommand split

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,7 @@ filemaker-ddr-viewer/
 │   ├── components/
 │   │   ├── navigation/CategoryTree.tsx
 │   │   └── detail/                 # 各詳細パネル
-│   ├── hooks/useTauriCommand.ts    # 全 invoke() はここに集約
+│   ├── hooks/                      # ドメイン別 IPC フック
 │   ├── stores/appStore.ts          # グローバル状態（zustand）
 │   └── types/ddr.ts                # 型定義
 ├── src-tauri/src/
@@ -112,7 +112,7 @@ filemaker-ddr-viewer/
 | `detail/field/FieldBasicProperties.tsx` 他 | FieldDetail のサブコンポーネント群（FieldAutoEnter / FieldCalcReferences / FieldLayoutReferences / FieldRelationshipReferences / FieldScriptReferences / FieldStorage / FieldValidationRules） |
 | `DiffView.tsx` | 差分比較ビュー |
 | `stores/appStore.ts` | グローバル状態（zustand） |
-| `hooks/useTauriCommand.ts` | 全 Tauri IPC フック |
+| `hooks/` | ドメイン別 Tauri IPC フック（analysis / catalog / diff / fieldRefs / layout / script / search / security / solutions / table） |
 | `hooks/useSearchFiltering.ts` | 検索フィルタリングロジック |
 | `styles/tokens.ts` | デザイントークン定数 |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,9 +122,7 @@ filemaker-ddr-viewer/
 │   │       ├── UpgradeSettingsPanel.tsx
 │   │       ├── CallChainTree.tsx
 │   │       └── WhereUsed.tsx
-│   ├── hooks/
-│   │   ├── useTauriCommand.ts
-│   │   └── useSearchFiltering.ts
+│   ├── hooks/                      # ドメイン別 IPC フック
 │   ├── styles/tokens.ts
 │   ├── stores/appStore.ts
 │   └── types/ddr.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ ci: CI 設定の変更
 ### TypeScript / React
 
 - 関数コンポーネント + hooks のみ。class component は使わない
-- `invoke()` の呼び出しは `src/hooks/useTauriCommand.ts` にまとめ、コンポーネントから直接呼ばない
+- `invoke()` の呼び出しは `src/hooks/` のドメイン別ファイルにまとめ、コンポーネントから直接呼ばない
 - グローバル状態は zustand、サーバー状態は @tanstack/react-query を使う
 
 ## テスト

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ filemaker-ddr-viewer/
 ├── src/                        # React フロントエンド
 │   ├── components/             # UI コンポーネント
 │   │   └── detail/             # 各詳細パネル
-│   ├── hooks/useTauriCommand.ts # Tauri IPC フック（全 invoke はここ）
+│   ├── hooks/                   # ドメイン別 IPC フック
 │   ├── stores/appStore.ts      # グローバル状態（Zustand）
 │   └── types/ddr.ts            # 型定義
 ├── src-tauri/                  # Rust バックエンド

--- a/docs/decisions/0005-always-fetch-list-data.md
+++ b/docs/decisions/0005-always-fetch-list-data.md
@@ -21,4 +21,4 @@
 
 ## 関連ファイル
 
-- `src/hooks/useTauriCommand.ts`
+- `src/hooks/catalog.ts`

--- a/docs/decisions/0006-field-calc-refs.md
+++ b/docs/decisions/0006-field-calc-refs.md
@@ -23,4 +23,4 @@ FTS5 で検索する案 → `fields` は `search_index` の `content` に入っ�
 
 - `src-tauri/src/commands/field_refs.rs`
 - `src/components/detail/FieldDetail.tsx`
-- `src/hooks/useTauriCommand.ts`
+- `src/hooks/fieldRefs.ts`


### PR DESCRIPTION
## Summary

- `useTauriCommand.ts` をドメイン別ファイルに分割した PR #38 に伴い、関連ドキュメントの参照が更新されていなかった箇所を修正

## 変更ファイル

| ファイル | 修正内容 |
|---|---|
| `ARCHITECTURE.md` | ディレクトリツリーとモジュール表の記述を更新 |
| `README.md` | ディレクトリツリーの記述を更新 |
| `CONTRIBUTING.md` | コーディング規約の記述を更新 |
| `CLAUDE.md` | ディレクトリツリーの記述を更新 |
| `docs/decisions/0005-*.md` | 関連ファイルを `catalog.ts` に更新 |
| `docs/decisions/0006-*.md` | 関連ファイルを `fieldRefs.ts` に更新 |

## Test plan

- [x] `grep -r "useTauriCommand" ...` で残存0件を確認済み
- [x] ロジック変更なし（ドキュメントのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)