### PR TITLE
fix(review): PR#42 レビュー指摘事項を修正

### DIFF
--- a/src/__tests__/detail/AllCustomFunctionsPanel.test.tsx
+++ b/src/__tests__/detail/AllCustomFunctionsPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { AllCustomFunctionsPanel } from "../../components/detail/AllCustomFunctionsPanel";
 import { makeCustomFunctionRow } from "../testFixtures";
+import { PAGE_SIZE } from "../../constants";
 
 vi.mock("../../hooks/catalog", () => ({
   useCustomFunctionList: vi.fn(),
@@ -13,8 +14,6 @@ vi.mock("../../stores/appStore", () => ({
 
 import { useCustomFunctionList } from "../../hooks/catalog";
 import { useAppStore } from "../../stores/appStore";
-
-const PAGE_SIZE = 500;
 
 const mockCFs = [
   makeCustomFunctionRow({ id: 1, fm_id: 1, name: "FormatDate", parameters: "date; format" }),
@@ -65,12 +64,13 @@ describe("AllCustomFunctionsPanel", () => {
     expect(screen.getByRole("button", { name: /次/ })).toBeDisabled();
   });
 
-  it("next_button_enabled_when_full_page", () => {
-    vi.mocked(useCustomFunctionList).mockReturnValue(
-      { data: fullPage, isLoading: false } as unknown as ReturnType<typeof useCustomFunctionList>
-    );
+  it("next_click_increments_offset", () => {
+    vi.mocked(useCustomFunctionList)
+      .mockReturnValueOnce({ data: fullPage, isLoading: false } as unknown as ReturnType<typeof useCustomFunctionList>)
+      .mockReturnValue({ data: mockCFs, isLoading: false } as unknown as ReturnType<typeof useCustomFunctionList>);
     render(<AllCustomFunctionsPanel projectId={1} />);
-    expect(screen.getByRole("button", { name: /次/ })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /次/ }));
+    expect(vi.mocked(useCustomFunctionList).mock.lastCall?.[2]).toBe(PAGE_SIZE);
   });
 
   it("filter_resets_page_to_zero", () => {

--- a/src/__tests__/detail/AllLayoutsPanel.test.tsx
+++ b/src/__tests__/detail/AllLayoutsPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { AllLayoutsPanel } from "../../components/detail/AllLayoutsPanel";
 import { makeLayoutRow } from "../testFixtures";
+import { PAGE_SIZE } from "../../constants";
 
 vi.mock("../../hooks/layout", () => ({
   useLayoutList: vi.fn(),
@@ -13,8 +14,6 @@ vi.mock("../../stores/appStore", () => ({
 
 import { useLayoutList } from "../../hooks/layout";
 import { useAppStore } from "../../stores/appStore";
-
-const PAGE_SIZE = 500;
 
 const mockLayouts = [
   makeLayoutRow({ id: 1, fm_id: 1, name: "Customer List", table_occurrence_name: "Customers", trigger_count: 2 }),
@@ -65,12 +64,13 @@ describe("AllLayoutsPanel", () => {
     expect(screen.getByRole("button", { name: /次/ })).toBeDisabled();
   });
 
-  it("next_button_enabled_when_full_page", () => {
-    vi.mocked(useLayoutList).mockReturnValue(
-      { data: fullPage, isLoading: false } as unknown as ReturnType<typeof useLayoutList>
-    );
+  it("next_click_increments_offset", () => {
+    vi.mocked(useLayoutList)
+      .mockReturnValueOnce({ data: fullPage, isLoading: false } as unknown as ReturnType<typeof useLayoutList>)
+      .mockReturnValue({ data: mockLayouts, isLoading: false } as unknown as ReturnType<typeof useLayoutList>);
     render(<AllLayoutsPanel projectId={1} />);
-    expect(screen.getByRole("button", { name: /次/ })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /次/ }));
+    expect(vi.mocked(useLayoutList).mock.lastCall?.[2]).toBe(PAGE_SIZE);
   });
 
   it("filter_resets_page_to_zero", () => {

--- a/src/__tests__/detail/AllRelationshipsPanel.test.tsx
+++ b/src/__tests__/detail/AllRelationshipsPanel.test.tsx
@@ -1,13 +1,21 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { AllRelationshipsPanel } from "../../components/detail/AllRelationshipsPanel";
 import { makeRelationshipRow, makePredicateRow } from "../testFixtures";
+import { PAGE_SIZE } from "../../constants";
 
 vi.mock("../../hooks/table", () => ({
   useRelationshipList: vi.fn(),
 }));
 
 import { useRelationshipList } from "../../hooks/table";
+
+const fullPageRels = Array.from({ length: PAGE_SIZE }, (_, i) =>
+  makeRelationshipRow({
+    id: i + 1, fm_id: i + 1, name: `Rel${i}`,
+    left_table: "A", right_table: "B", predicates: [],
+  })
+);
 
 const mockRelationships = [
   makeRelationshipRow({
@@ -47,6 +55,42 @@ describe("AllRelationshipsPanel", () => {
     // 2件目のリレーション: 述語が2件とも表示される
     expect(screen.getByText("Orders::id = LineItems::order_id")).toBeInTheDocument();
     expect(screen.getByText("Orders::status = LineItems::status")).toBeInTheDocument();
+  });
+
+  it("prev_button_disabled_on_first_page", () => {
+    vi.mocked(useRelationshipList).mockReturnValue(
+      { data: mockRelationships, isLoading: false } as unknown as ReturnType<typeof useRelationshipList>
+    );
+    render(<AllRelationshipsPanel projectId={1} />);
+    expect(screen.getByRole("button", { name: /前/ })).toBeDisabled();
+  });
+
+  it("next_button_disabled_when_last_page", () => {
+    vi.mocked(useRelationshipList).mockReturnValue(
+      { data: mockRelationships, isLoading: false } as unknown as ReturnType<typeof useRelationshipList>
+    );
+    render(<AllRelationshipsPanel projectId={1} />);
+    expect(screen.getByRole("button", { name: /次/ })).toBeDisabled();
+  });
+
+  it("next_click_increments_offset", () => {
+    vi.mocked(useRelationshipList)
+      .mockReturnValueOnce({ data: fullPageRels, isLoading: false } as unknown as ReturnType<typeof useRelationshipList>)
+      .mockReturnValue({ data: mockRelationships, isLoading: false } as unknown as ReturnType<typeof useRelationshipList>);
+    render(<AllRelationshipsPanel projectId={1} />);
+    fireEvent.click(screen.getByRole("button", { name: /次/ }));
+    expect(vi.mocked(useRelationshipList).mock.lastCall?.[2]).toBe(PAGE_SIZE);
+  });
+
+  it("filter_resets_page_to_zero", () => {
+    vi.mocked(useRelationshipList).mockReturnValue(
+      { data: fullPageRels, isLoading: false } as unknown as ReturnType<typeof useRelationshipList>
+    );
+    render(<AllRelationshipsPanel projectId={1} />);
+    fireEvent.click(screen.getByRole("button", { name: /次/ }));
+    fireEvent.change(screen.getByPlaceholderText(/絞り込み/), { target: { value: "x" } });
+    const calls = vi.mocked(useRelationshipList).mock.calls;
+    expect(calls[calls.length - 1][2]).toBe(0);
   });
 
 });

--- a/src/__tests__/detail/AllScriptsPanel.test.tsx
+++ b/src/__tests__/detail/AllScriptsPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { AllScriptsPanel } from "../../components/detail/AllScriptsPanel";
 import { makeScriptRow } from "../testFixtures";
+import { PAGE_SIZE } from "../../constants";
 
 vi.mock("../../hooks/script", () => ({
   useScriptList: vi.fn(),
@@ -13,8 +14,6 @@ vi.mock("../../stores/appStore", () => ({
 
 import { useScriptList } from "../../hooks/script";
 import { useAppStore } from "../../stores/appStore";
-
-const PAGE_SIZE = 500;
 
 const mockScripts = [
   makeScriptRow({ id: 1, fm_id: 1, name: "Save Record", step_count: 5 }),
@@ -65,12 +64,13 @@ describe("AllScriptsPanel", () => {
     expect(screen.getByRole("button", { name: /次/ })).toBeDisabled();
   });
 
-  it("next_button_enabled_when_full_page", () => {
-    vi.mocked(useScriptList).mockReturnValue(
-      { data: fullPage, isLoading: false } as unknown as ReturnType<typeof useScriptList>
-    );
+  it("next_click_increments_offset", () => {
+    vi.mocked(useScriptList)
+      .mockReturnValueOnce({ data: fullPage, isLoading: false } as unknown as ReturnType<typeof useScriptList>)
+      .mockReturnValue({ data: mockScripts, isLoading: false } as unknown as ReturnType<typeof useScriptList>);
     render(<AllScriptsPanel projectId={1} />);
-    expect(screen.getByRole("button", { name: /次/ })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /次/ }));
+    expect(vi.mocked(useScriptList).mock.lastCall?.[2]).toBe(PAGE_SIZE);
   });
 
   it("filter_resets_page_to_zero", () => {

--- a/src/__tests__/detail/AllTableOccurrencesPanel.test.tsx
+++ b/src/__tests__/detail/AllTableOccurrencesPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { AllTableOccurrencesPanel } from "../../components/detail/AllTableOccurrencesPanel";
 import { makeTableOccurrenceRow, makeTableRow, makeLayoutRow } from "../testFixtures";
+import { PAGE_SIZE } from "../../constants";
 
 vi.mock("../../hooks/table", () => ({
   useTableOccurrenceList: vi.fn(),
@@ -18,8 +19,6 @@ vi.mock("../../stores/appStore", () => ({
 import { useTableOccurrenceList, useTableList } from "../../hooks/table";
 import { useLayoutList } from "../../hooks/layout";
 import { useAppStore } from "../../stores/appStore";
-
-const PAGE_SIZE = 500;
 
 const mockTOs = [
   makeTableOccurrenceRow({ id: 1, occurrence_name: "Customers", base_table_name: "Customer" }),
@@ -75,15 +74,16 @@ describe("AllTableOccurrencesPanel", () => {
     expect(screen.getByRole("button", { name: /次/ })).toBeDisabled();
   });
 
-  it("next_button_enabled_when_full_page", { timeout: 15000 }, () => {
-    vi.mocked(useTableOccurrenceList).mockReturnValue(
-      { data: fullPageTOs, isLoading: false } as unknown as ReturnType<typeof useTableOccurrenceList>
-    );
+  it("next_click_increments_offset", () => {
+    vi.mocked(useTableOccurrenceList)
+      .mockReturnValueOnce({ data: fullPageTOs, isLoading: false } as unknown as ReturnType<typeof useTableOccurrenceList>)
+      .mockReturnValue({ data: mockTOs, isLoading: false } as unknown as ReturnType<typeof useTableOccurrenceList>);
     render(<AllTableOccurrencesPanel projectId={1} />);
-    expect(screen.getByRole("button", { name: /次/ })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /次/ }));
+    expect(vi.mocked(useTableOccurrenceList).mock.lastCall?.[2]).toBe(PAGE_SIZE);
   });
 
-  it("filter_resets_page_to_zero", { timeout: 15000 }, () => {
+  it("filter_resets_page_to_zero", () => {
     vi.mocked(useTableOccurrenceList).mockReturnValue(
       { data: fullPageTOs, isLoading: false } as unknown as ReturnType<typeof useTableOccurrenceList>
     );

--- a/src/__tests__/detail/AllTablesPanel.test.tsx
+++ b/src/__tests__/detail/AllTablesPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { AllTablesPanel } from "../../components/detail/AllTablesPanel";
 import { makeTableRow } from "../testFixtures";
+import { PAGE_SIZE } from "../../constants";
 
 vi.mock("../../hooks/table", () => ({
   useTableList: vi.fn(),
@@ -13,8 +14,6 @@ vi.mock("../../stores/appStore", () => ({
 
 import { useTableList } from "../../hooks/table";
 import { useAppStore } from "../../stores/appStore";
-
-const PAGE_SIZE = 500;
 
 const mockTables = [
   makeTableRow({ id: 1, fm_id: 1, name: "Customer", field_count: 10 }),
@@ -65,12 +64,13 @@ describe("AllTablesPanel", () => {
     expect(screen.getByRole("button", { name: /次/ })).toBeDisabled();
   });
 
-  it("next_button_enabled_when_full_page", () => {
-    vi.mocked(useTableList).mockReturnValue(
-      { data: fullPage, isLoading: false } as unknown as ReturnType<typeof useTableList>
-    );
+  it("next_click_increments_offset", () => {
+    vi.mocked(useTableList)
+      .mockReturnValueOnce({ data: fullPage, isLoading: false } as unknown as ReturnType<typeof useTableList>)
+      .mockReturnValue({ data: mockTables, isLoading: false } as unknown as ReturnType<typeof useTableList>);
     render(<AllTablesPanel projectId={1} />);
-    expect(screen.getByRole("button", { name: /次/ })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /次/ }));
+    expect(vi.mocked(useTableList).mock.lastCall?.[2]).toBe(PAGE_SIZE);
   });
 
   it("filter_resets_page_to_zero", () => {

--- a/src/__tests__/detail/AllValueListsPanel.test.tsx
+++ b/src/__tests__/detail/AllValueListsPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { AllValueListsPanel } from "../../components/detail/AllValueListsPanel";
 import { makeValueListRow } from "../testFixtures";
+import { PAGE_SIZE } from "../../constants";
 
 vi.mock("../../hooks/catalog", () => ({
   useValueListList: vi.fn(),
@@ -13,8 +14,6 @@ vi.mock("../../stores/appStore", () => ({
 
 import { useValueListList } from "../../hooks/catalog";
 import { useAppStore } from "../../stores/appStore";
-
-const PAGE_SIZE = 500;
 
 const mockValueLists = [
   makeValueListRow({ id: 1, fm_id: 1, name: "Status", item_count: 3 }),
@@ -65,12 +64,13 @@ describe("AllValueListsPanel", () => {
     expect(screen.getByRole("button", { name: /次/ })).toBeDisabled();
   });
 
-  it("next_button_enabled_when_full_page", () => {
-    vi.mocked(useValueListList).mockReturnValue(
-      { data: fullPage, isLoading: false } as unknown as ReturnType<typeof useValueListList>
-    );
+  it("next_click_increments_offset", () => {
+    vi.mocked(useValueListList)
+      .mockReturnValueOnce({ data: fullPage, isLoading: false } as unknown as ReturnType<typeof useValueListList>)
+      .mockReturnValue({ data: mockValueLists, isLoading: false } as unknown as ReturnType<typeof useValueListList>);
     render(<AllValueListsPanel projectId={1} />);
-    expect(screen.getByRole("button", { name: /次/ })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /次/ }));
+    expect(vi.mocked(useValueListList).mock.lastCall?.[2]).toBe(PAGE_SIZE);
   });
 
   it("filter_resets_page_to_zero", () => {

--- a/src/components/detail/AllCustomFunctionsPanel.tsx
+++ b/src/components/detail/AllCustomFunctionsPanel.tsx
@@ -2,8 +2,8 @@ import { useState, useMemo } from "react";
 import { useCustomFunctionList } from "../../hooks/catalog";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
+import { PAGE_SIZE } from "../../constants";
 
-const PAGE_SIZE = 500;
 
 interface Props {
   projectId: number;

--- a/src/components/detail/AllFieldsPanel.tsx
+++ b/src/components/detail/AllFieldsPanel.tsx
@@ -2,8 +2,8 @@ import { useState, useMemo } from "react";
 import { useAllFields } from "../../hooks/table";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
+import { PAGE_SIZE } from "../../constants";
 
-const PAGE_SIZE = 500;
 
 interface Props {
   projectId: number;

--- a/src/components/detail/AllLayoutsPanel.tsx
+++ b/src/components/detail/AllLayoutsPanel.tsx
@@ -2,8 +2,8 @@ import { useState, useMemo } from "react";
 import { useLayoutList } from "../../hooks/layout";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
+import { PAGE_SIZE } from "../../constants";
 
-const PAGE_SIZE = 500;
 
 interface Props {
   projectId: number;

--- a/src/components/detail/AllRelationshipsPanel.tsx
+++ b/src/components/detail/AllRelationshipsPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect, useRef } from "react";
 import { useRelationshipList } from "../../hooks/table";
 import type { RelationshipRow } from "../../types/ddr";
 import { Spinner } from "../Spinner";
+import { PAGE_SIZE } from "../../constants";
 
 interface Props {
   projectId: number;
@@ -15,15 +16,22 @@ function predicateLines(rel: RelationshipRow): string[] {
 }
 
 export function AllRelationshipsPanel({ projectId, highlightId }: Props) {
-  const { data: relationships = [], isLoading } = useRelationshipList(projectId);
+  const [page, setPage] = useState(0);
   const [filter, setFilter] = useState("");
+  const { data: relationships = [], isLoading } = useRelationshipList(projectId, PAGE_SIZE, page * PAGE_SIZE);
   const highlightRef = useRef<HTMLTableRowElement>(null);
+  const isLastPage = relationships.length < PAGE_SIZE;
 
   useEffect(() => {
     if (highlightRef.current) {
       highlightRef.current.scrollIntoView({ block: "center" });
     }
   }, [highlightId, isLoading]);
+
+  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilter(e.target.value);
+    setPage(0);
+  };
 
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase();
@@ -51,16 +59,35 @@ export function AllRelationshipsPanel({ projectId, highlightId }: Props) {
         <h2 className="text-lg font-bold text-gray-800 mb-2">
           リレーション一覧
           <span className="ml-2 text-sm font-normal text-gray-500">
-            {filtered.length} / {relationships.length} 件
+            {filtered.length} 件
           </span>
         </h2>
-        <input
-          type="text"
-          placeholder="テーブル名・フィールド名で絞り込み..."
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-          className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
-        />
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            placeholder="テーブル名・フィールド名で絞り込み..."
+            value={filter}
+            onChange={handleFilterChange}
+            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
+          />
+          <button
+            onClick={() => setPage((p) => p - 1)}
+            disabled={page === 0}
+            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            &lt; 前
+          </button>
+          <span className="text-sm text-gray-600 whitespace-nowrap">
+            {page + 1} ページ
+          </span>
+          <button
+            onClick={() => setPage((p) => p + 1)}
+            disabled={isLastPage}
+            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            次 &gt;
+          </button>
+        </div>
       </div>
 
       {/* テーブル */}

--- a/src/components/detail/AllScriptsPanel.tsx
+++ b/src/components/detail/AllScriptsPanel.tsx
@@ -2,8 +2,8 @@ import { useState, useMemo } from "react";
 import { useScriptList } from "../../hooks/script";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
+import { PAGE_SIZE } from "../../constants";
 
-const PAGE_SIZE = 500;
 
 interface Props {
   projectId: number;

--- a/src/components/detail/AllTableOccurrencesPanel.tsx
+++ b/src/components/detail/AllTableOccurrencesPanel.tsx
@@ -5,8 +5,8 @@ import { useTableOccurrenceList, useTableList } from "../../hooks/table";
 import { useLayoutList } from "../../hooks/layout";
 import { useAppStore } from "../../stores/appStore";
 import type { LayoutRow } from "../../types/ddr";
+import { PAGE_SIZE } from "../../constants";
 
-const PAGE_SIZE = 500;
 
 interface Props {
   projectId: number;

--- a/src/components/detail/AllTablesPanel.tsx
+++ b/src/components/detail/AllTablesPanel.tsx
@@ -2,8 +2,8 @@ import { useState, useMemo } from "react";
 import { useTableList } from "../../hooks/table";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
+import { PAGE_SIZE } from "../../constants";
 
-const PAGE_SIZE = 500;
 
 interface Props {
   projectId: number;

--- a/src/components/detail/AllValueListsPanel.tsx
+++ b/src/components/detail/AllValueListsPanel.tsx
@@ -2,8 +2,8 @@ import { useState, useMemo } from "react";
 import { useValueListList } from "../../hooks/catalog";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
+import { PAGE_SIZE } from "../../constants";
 
-const PAGE_SIZE = 500;
 
 interface Props {
   projectId: number;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const PAGE_SIZE = 500;


### PR DESCRIPTION
## Summary

- `AllRelationshipsPanel` にページネーション UI を追加（他の All*Panel と同パターン）
- `{ timeout: 15000 }` を削除し `next_click_increments_offset` パターンに設計改善（CLAUDE.md 準拠）
- `PAGE_SIZE = 500` を `src/constants.ts` に集約し全コンポーネントで import に変更

## Test plan

- [ ] `npm run test` → 302件グリーン確認済み
- [ ] `AllRelationshipsPanel` の前/次ボタン動作確認
- [ ] `{ timeout: 15000 }` が全テストから削除されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)