### PR TITLE
feat: E2E CI 有効化 + CLAUDE.md TDD テンプレート更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,32 +105,30 @@ jobs:
           files: coverage/lcov.info
           flags: frontend
 
-# E2E テストを CI に追加する場合の手順:
-#
-# e2e:
-#   name: E2E (local-only for now)
-#   runs-on: windows-latest
-#   steps:
-#     - uses: actions/checkout@v4
-#     - uses: actions/setup-node@v4
-#       with: { node-version: 20, cache: npm }
-#     - uses: dtolnay/rust-toolchain@stable
-#     - name: Cache Rust
-#       uses: Swatinem/rust-cache@v2
-#       with:
-#         workspaces: src-tauri
-#     - name: Install dependencies
-#       run: npm ci
-#     - name: Install Playwright browsers
-#       run: npx playwright install chromium --with-deps
-#     - name: Build E2E binary (test-utils + CDP enabled)
-#       run: npm run build:e2e
-#       # 展開: npx tauri build --debug --features test-utils
-#       # 所要時間: 約 8-10 分（Rust-cache なしの場合）
-#     - name: Run E2E tests
-#       run: npx playwright test
-#
-# 注意:
-# - ビルド時間が長いため別 job でバイナリをビルドして artifact 経由で受け取ると高速化できる
-# - tauri-driver / msedgedriver は不要（Playwright + CDP 直接接続のため）
-# - CDP ポート 9222 が他のプロセスと競合しないことを確認すること
+  e2e:
+    name: E2E
+    runs-on: windows-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: npm }
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+      - name: Build E2E binary (test-utils + CDP enabled)
+        run: npm run build:e2e
+      - name: Run E2E tests
+        run: npm run test:e2e:run
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-results
+          path: test-results/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
     name: E2E
     runs-on: windows-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,9 @@ filemaker-ddr-viewer/
 ## タスクリスト
 
 - [ ] ブランチ作成: `main` → `fix/add-broken-field-detection`  ← 作成元と実際のブランチ名を記載
+- [ ] `/test-spec` 実行（テスト仕様をファイルに生成）
 - [ ] テスト追加（Red確認）: `src/__tests__/.../Foo.test.tsx` または `broken_refs.rs` の `#[cfg(test)]`
+- [ ] `/tdd-guard` 実行（実装に入る前にテストが先に書かれているか確認）
 - [ ] 実装（Green確認）: 対象の `.tsx` / `.rs`
 - [ ] `cargo fmt` / `cargo clippy` / `tsc --noEmit` パス確認
 - [ ] `/pre-pr` 実行・全チェック通過

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "build:e2e": "npx tauri build --debug --features test-utils",
-    "test:e2e": "npm run build:e2e && npx playwright test"
+    "test:e2e": "npm run build:e2e && npx playwright test",
+    "test:e2e:run": "npx playwright test"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: main push 時のみ実行する E2E ジョブを有効化（コメントアウト解除）。失敗時にスクリーンショットを artifact として保存
- `package.json`: `test:e2e:run` スクリプトを追加（ビルドをスキップして Playwright だけ実行）
- `CLAUDE.md`: タスクリストテンプレートに `/test-spec`（テスト仕様生成）と `/tdd-guard`（実装前テスト存在確認）ステップを追加

## E2E CI について

GitHub Actions の `windows-latest` は WebView2 標準搭載のため技術的に動作可能。
Playwright + CDP 直接接続方式のため tauri-driver は不要。
ビルドに 8-10 分かかるため、PR ごとではなく main へのマージ後のみ実行する設計。

## Test plan

- [x] CI が通ること（Rust/Frontend ジョブ）
- [ ] main へのマージ後、Actions で E2E ジョブが実行されること
- [ ] 次回プランモード時のタスクリストに `/test-spec` と `/tdd-guard` が含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)