### PR TITLE
feat: アップグレードチェックに「壊れた参照」セクションを追加 + UnknownRef 検出

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,11 +109,11 @@ filemaker-ddr-viewer/
 | `detail/CallChainTree.tsx` | コールチェーンツリー |
 | `detail/WhereUsed.tsx` | 参照元一覧 |
 | `detail/SecurityPanel.tsx` | アカウント・権限セット |
-| `detail/UpgradeCheckPanel.tsx` / `UpgradeSettingsPanel.tsx` | アップグレードチェック |
+| `detail/UpgradeCheckPanel.tsx` / `UpgradeSettingsPanel.tsx` | アップグレードチェック（DBスキャン項目 + 壊れた参照セクション）。壊れた参照は `useSolutionBrokenRefs` で全プロジェクトを集約して表示 |
 | `detail/field/FieldBasicProperties.tsx` 他 | FieldDetail のサブコンポーネント群（FieldAutoEnter / FieldCalcReferences / FieldLayoutReferences / FieldRelationshipReferences / FieldScriptReferences / FieldStorage / FieldValidationRules） |
 | `DiffView.tsx` | 差分比較ビュー |
 | `stores/appStore.ts` | グローバル状態（zustand） |
-| `hooks/` | ドメイン別 Tauri IPC フック（analysis / catalog / diff / fieldRefs / layout / script / search / security / solutions / table） |
+| `hooks/` | ドメイン別 Tauri IPC フック（analysis / catalog / diff / fieldRefs / layout / script / search / security / solutions / table）。`hooks/analysis.ts` の `useSolutionBrokenRefs` はソリューション全プロジェクトの壊れた参照を `Promise.all` で集約 |
 | `hooks/useSearchFiltering.ts` | 検索フィルタリングロジック |
 | `styles/tokens.ts` | デザイントークン定数 |
 

--- a/src-tauri/src/analyzer/broken_refs.rs
+++ b/src-tauri/src/analyzer/broken_refs.rs
@@ -25,6 +25,9 @@ pub enum BrokenRefKind {
     /// step_text に `<不明>` が含まれており、他の broken ref 種別で未検出のケース。
     /// 例: ファイルを開く・Perform Script の外部参照先不明 等。
     UnknownRef,
+    /// レイアウト上のフィールドオブジェクトが存在しないフィールドを参照している
+    /// （フィールド削除済み・外部データソース切断など）。
+    BrokenFieldPlacement,
 }
 
 /// 単一の壊れた参照。
@@ -139,6 +142,24 @@ pub fn find_broken_refs(ddr: &DdrFile) -> Vec<BrokenRef> {
                     target_script_name: trigger.script_name.clone(),
                     source_id: None,
                 });
+            }
+        }
+    }
+
+    // レイアウト上のフィールドオブジェクトで name/table が空のケース（フィールド削除済み等）
+    for layout in ddr.layouts.iter().filter(|l| l.name != "-") {
+        for obj in &layout.layout_objects {
+            if obj.object_type == "Field" {
+                let is_broken = obj.field_table_occurrence.as_deref() == Some("")
+                    || obj.field_name.as_deref() == Some("");
+                if is_broken {
+                    result.push(BrokenRef {
+                        kind: BrokenRefKind::BrokenFieldPlacement,
+                        source_name: layout.name.clone(),
+                        target_script_name: format!("(フィールド削除済み) #{}", obj.object_key),
+                        source_id: None,
+                    });
+                }
             }
         }
     }
@@ -596,6 +617,117 @@ mod tests {
             "BrokenLayoutRef のみ、UnknownRef との重複なし: {refs:?}"
         );
         assert_eq!(refs[0].kind, BrokenRefKind::BrokenLayoutRef);
+    }
+
+    #[test]
+    fn detects_broken_layout_field_placement() {
+        use crate::parser::models::*;
+        use crate::parser::version::FmVersion;
+
+        let ddr = DdrFile {
+            file_name: "Test".into(),
+            fm_version: FmVersion {
+                major: 22,
+                minor: 0,
+                patch: "v1".into(),
+            },
+            tables: vec![],
+            scripts: vec![],
+            layouts: vec![Layout {
+                id: LayoutId(1),
+                name: "CustomerLayout".into(),
+                table_occurrence_name: None,
+                script_triggers: vec![],
+                button_script_refs: vec![],
+                field_refs: vec![],
+                layout_objects: vec![LayoutObject {
+                    object_type: "Field".into(),
+                    object_key: 7,
+                    object_name: None,
+                    button_label: None,
+                    field_table_occurrence: Some("".into()),
+                    field_name: Some("".into()),
+                    tooltip: None,
+                    hide_condition: None,
+                    bounds: None,
+                    conditional_formats: vec![],
+                }],
+            }],
+            relationships: vec![],
+            value_lists: vec![],
+            custom_functions: vec![],
+            accounts: vec![],
+            privilege_sets: vec![],
+            table_occurrences: vec![],
+            file_script_triggers: vec![],
+            external_data_sources: vec![],
+        };
+
+        let refs = find_broken_refs(&ddr);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].kind, BrokenRefKind::BrokenFieldPlacement);
+        assert_eq!(refs[0].source_name, "CustomerLayout");
+        assert!(
+            refs[0].target_script_name.contains("フィールド削除済み"),
+            "expected description, got: {}",
+            refs[0].target_script_name
+        );
+        assert!(
+            refs[0].target_script_name.contains("#7"),
+            "expected object key #7, got: {}",
+            refs[0].target_script_name
+        );
+    }
+
+    #[test]
+    fn non_field_objects_not_detected_as_broken_placement() {
+        use crate::parser::models::*;
+        use crate::parser::version::FmVersion;
+
+        let ddr = DdrFile {
+            file_name: "Test".into(),
+            fm_version: FmVersion {
+                major: 22,
+                minor: 0,
+                patch: "v1".into(),
+            },
+            tables: vec![],
+            scripts: vec![],
+            layouts: vec![Layout {
+                id: LayoutId(1),
+                name: "CustomerLayout".into(),
+                table_occurrence_name: None,
+                script_triggers: vec![],
+                button_script_refs: vec![],
+                field_refs: vec![],
+                layout_objects: vec![LayoutObject {
+                    object_type: "Text".into(), // Text object, not Field
+                    object_key: 3,
+                    object_name: None,
+                    button_label: None,
+                    field_table_occurrence: None,
+                    field_name: None,
+                    tooltip: None,
+                    hide_condition: None,
+                    bounds: None,
+                    conditional_formats: vec![],
+                }],
+            }],
+            relationships: vec![],
+            value_lists: vec![],
+            custom_functions: vec![],
+            accounts: vec![],
+            privilege_sets: vec![],
+            table_occurrences: vec![],
+            file_script_triggers: vec![],
+            external_data_sources: vec![],
+        };
+
+        let refs = find_broken_refs(&ddr);
+        assert!(
+            refs.is_empty(),
+            "Text objects should not be detected as broken: {refs:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/analyzer/broken_refs.rs
+++ b/src-tauri/src/analyzer/broken_refs.rs
@@ -22,6 +22,9 @@ pub enum BrokenRefKind {
     BrokenFieldRef,
     /// Go to Layout 等のステップが存在しないレイアウトを参照している。
     BrokenLayoutRef,
+    /// step_text に `<不明>` が含まれており、他の broken ref 種別で未検出のケース。
+    /// 例: ファイルを開く・Perform Script の外部参照先不明 等。
+    UnknownRef,
 }
 
 /// 単一の壊れた参照。
@@ -78,7 +81,8 @@ pub fn find_broken_refs(ddr: &DdrFile) -> Vec<BrokenRef> {
             }
         }
 
-        // 壊れたフィールド参照（Set Field 等）
+        // 壊れたフィールド参照（Set Field 等）、レイアウト参照、
+        // および step_text に <不明> を含む未分類の参照切れを検出
         for step in script.steps.iter().filter(|s| s.enabled) {
             if step.broken_field_table.is_some() {
                 let target = step.step_text.as_deref().unwrap_or("(broken field ref)");
@@ -87,14 +91,31 @@ pub fn find_broken_refs(ddr: &DdrFile) -> Vec<BrokenRef> {
                     source_name: script.name.clone(),
                     target_script_name: target.to_string(),
                 });
-            }
-            if step.has_broken_layout_ref {
+            } else if step.has_broken_layout_ref {
                 let target = step.step_text.as_deref().unwrap_or("(broken layout ref)");
                 result.push(BrokenRef {
                     kind: BrokenRefKind::BrokenLayoutRef,
                     source_name: script.name.clone(),
                     target_script_name: target.to_string(),
                 });
+            } else {
+                // step_text に <不明> が含まれるケース（ファイルを開く・Perform Script 外部参照等）
+                let is_script_ref_unknown = step
+                    .script_ref
+                    .as_ref()
+                    .is_some_and(|r| r.name.starts_with('<'));
+                let has_unknown_in_text = step
+                    .step_text
+                    .as_deref()
+                    .is_some_and(|t| t.contains("<不明>"));
+                if has_unknown_in_text || is_script_ref_unknown {
+                    let target = step.step_text.clone().unwrap_or_else(|| step.name.clone());
+                    result.push(BrokenRef {
+                        kind: BrokenRefKind::UnknownRef,
+                        source_name: script.name.clone(),
+                        target_script_name: target,
+                    });
+                }
             }
         }
     }
@@ -425,6 +446,149 @@ mod tests {
         assert_eq!(refs[0].kind, BrokenRefKind::ScriptTrigger);
         assert_eq!(refs[0].source_name, "MainLayout");
         assert_eq!(refs[0].target_script_name, "MissingScript");
+    }
+
+    #[test]
+    fn detects_open_file_unknown_step() {
+        use crate::parser::models::*;
+        use crate::parser::version::FmVersion;
+
+        let ddr = DdrFile {
+            file_name: "Test".into(),
+            fm_version: FmVersion {
+                major: 22,
+                minor: 0,
+                patch: "v1".into(),
+            },
+            tables: vec![],
+            scripts: vec![Script {
+                id: ScriptId(1),
+                name: "物件管理を開く！".into(),
+                run_with_full_access: false,
+                steps: vec![ScriptStep {
+                    step_id: 148,
+                    name: "ファイルを開く".into(),
+                    enabled: true,
+                    script_ref: None,
+                    calculation: None,
+                    step_text: Some("ファイルを開く [ <不明> ]".into()),
+                    broken_field_table: None,
+                    has_broken_layout_ref: false,
+                }],
+            }],
+            layouts: vec![],
+            relationships: vec![],
+            value_lists: vec![],
+            custom_functions: vec![],
+            accounts: vec![],
+            privilege_sets: vec![],
+            table_occurrences: vec![],
+            file_script_triggers: vec![],
+            external_data_sources: vec![],
+        };
+
+        let refs = find_broken_refs(&ddr);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].kind, BrokenRefKind::UnknownRef);
+        assert_eq!(refs[0].source_name, "物件管理を開く！");
+        assert!(refs[0].target_script_name.contains("不明"));
+    }
+
+    #[test]
+    fn detects_perform_script_with_angle_bracket_ref() {
+        use crate::parser::models::*;
+        use crate::parser::version::FmVersion;
+
+        let ddr = DdrFile {
+            file_name: "Test".into(),
+            fm_version: FmVersion {
+                major: 22,
+                minor: 0,
+                patch: "v1".into(),
+            },
+            tables: vec![],
+            scripts: vec![Script {
+                id: ScriptId(1),
+                name: "Caller".into(),
+                run_with_full_access: false,
+                steps: vec![ScriptStep {
+                    step_id: 89,
+                    name: "Perform Script".into(),
+                    enabled: true,
+                    script_ref: Some(ScriptRef {
+                        name: "<不明>".into(),
+                        file_name: "".into(),
+                    }),
+                    calculation: None,
+                    step_text: Some("Perform Script [ \"<不明>\"; off ]".into()),
+                    broken_field_table: None,
+                    has_broken_layout_ref: false,
+                }],
+            }],
+            layouts: vec![],
+            relationships: vec![],
+            value_lists: vec![],
+            custom_functions: vec![],
+            accounts: vec![],
+            privilege_sets: vec![],
+            table_occurrences: vec![],
+            file_script_triggers: vec![],
+            external_data_sources: vec![],
+        };
+
+        let refs = find_broken_refs(&ddr);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].kind, BrokenRefKind::UnknownRef);
+        assert_eq!(refs[0].source_name, "Caller");
+    }
+
+    #[test]
+    fn no_duplicate_for_broken_layout_ref() {
+        use crate::parser::models::*;
+        use crate::parser::version::FmVersion;
+
+        // has_broken_layout_ref=true のステップは BrokenLayoutRef のみ（UnknownRef との重複なし）
+        let ddr = DdrFile {
+            file_name: "Test".into(),
+            fm_version: FmVersion {
+                major: 22,
+                minor: 0,
+                patch: "v1".into(),
+            },
+            tables: vec![],
+            scripts: vec![Script {
+                id: ScriptId(1),
+                name: "NavScript".into(),
+                run_with_full_access: false,
+                steps: vec![ScriptStep {
+                    step_id: 6,
+                    name: "レイアウト切り替え".into(),
+                    enabled: true,
+                    script_ref: None,
+                    calculation: None,
+                    step_text: Some("レイアウト切り替え [ <不明> ]".into()),
+                    broken_field_table: None,
+                    has_broken_layout_ref: true,
+                }],
+            }],
+            layouts: vec![],
+            relationships: vec![],
+            value_lists: vec![],
+            custom_functions: vec![],
+            accounts: vec![],
+            privilege_sets: vec![],
+            table_occurrences: vec![],
+            file_script_triggers: vec![],
+            external_data_sources: vec![],
+        };
+
+        let refs = find_broken_refs(&ddr);
+        assert_eq!(
+            refs.len(),
+            1,
+            "BrokenLayoutRef のみ、UnknownRef との重複なし: {refs:?}"
+        );
+        assert_eq!(refs[0].kind, BrokenRefKind::BrokenLayoutRef);
     }
 
     #[test]

--- a/src-tauri/src/analyzer/broken_refs.rs
+++ b/src-tauri/src/analyzer/broken_refs.rs
@@ -35,6 +35,8 @@ pub struct BrokenRef {
     pub source_name: String,
     /// 参照しようとしているスクリプト名。
     pub target_script_name: String,
+    /// 参照元要素の SQLite DB ID（コマンド層で解決される。解決不能な場合は None）。
+    pub source_id: Option<i64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -77,6 +79,7 @@ pub fn find_broken_refs(ddr: &DdrFile) -> Vec<BrokenRef> {
                     kind: BrokenRefKind::PerformScript,
                     source_name: script.name.clone(),
                     target_script_name: script_ref.name.clone(),
+                    source_id: None,
                 });
             }
         }
@@ -90,6 +93,7 @@ pub fn find_broken_refs(ddr: &DdrFile) -> Vec<BrokenRef> {
                     kind: BrokenRefKind::BrokenFieldRef,
                     source_name: script.name.clone(),
                     target_script_name: target.to_string(),
+                    source_id: None,
                 });
             } else if step.has_broken_layout_ref {
                 let target = step.step_text.as_deref().unwrap_or("(broken layout ref)");
@@ -97,6 +101,7 @@ pub fn find_broken_refs(ddr: &DdrFile) -> Vec<BrokenRef> {
                     kind: BrokenRefKind::BrokenLayoutRef,
                     source_name: script.name.clone(),
                     target_script_name: target.to_string(),
+                    source_id: None,
                 });
             } else {
                 // step_text に <不明> が含まれるケース（ファイルを開く・Perform Script 外部参照等）
@@ -114,6 +119,7 @@ pub fn find_broken_refs(ddr: &DdrFile) -> Vec<BrokenRef> {
                         kind: BrokenRefKind::UnknownRef,
                         source_name: script.name.clone(),
                         target_script_name: target,
+                        source_id: None,
                     });
                 }
             }
@@ -131,6 +137,7 @@ pub fn find_broken_refs(ddr: &DdrFile) -> Vec<BrokenRef> {
                     kind: BrokenRefKind::ScriptTrigger,
                     source_name: layout.name.clone(),
                     target_script_name: trigger.script_name.clone(),
+                    source_id: None,
                 });
             }
         }

--- a/src-tauri/src/analyzer/broken_refs.rs
+++ b/src-tauri/src/analyzer/broken_refs.rs
@@ -129,7 +129,7 @@ pub fn find_broken_refs(ddr: &DdrFile) -> Vec<BrokenRef> {
         }
     }
 
-    // ScriptTrigger の確認（区切り線レイアウト "-" からの参照は除外）
+    // ScriptTrigger と BrokenFieldPlacement の確認（区切り線レイアウト "-" は除外）
     for layout in ddr.layouts.iter().filter(|l| l.name != "-") {
         for trigger in &layout.script_triggers {
             if !trigger.file_name.is_empty() || trigger.script_name.is_empty() {
@@ -144,14 +144,13 @@ pub fn find_broken_refs(ddr: &DdrFile) -> Vec<BrokenRef> {
                 });
             }
         }
-    }
-
-    // レイアウト上のフィールドオブジェクトで name/table が空のケース（フィールド削除済み等）
-    for layout in ddr.layouts.iter().filter(|l| l.name != "-") {
         for obj in &layout.layout_objects {
             if obj.object_type == "Field" {
-                let is_broken = obj.field_table_occurrence.as_deref() == Some("")
-                    || obj.field_name.as_deref() == Some("");
+                let is_broken = obj
+                    .field_table_occurrence
+                    .as_deref()
+                    .is_some_and(|s| s.is_empty())
+                    || obj.field_name.as_deref().is_some_and(|s| s.is_empty());
                 if is_broken {
                     result.push(BrokenRef {
                         kind: BrokenRefKind::BrokenFieldPlacement,

--- a/src-tauri/src/analyzer/orphans.rs
+++ b/src-tauri/src/analyzer/orphans.rs
@@ -34,9 +34,12 @@ pub fn find_orphan_scripts(ddr: &DdrFile) -> Vec<OrphanScript> {
     // 呼ばれているスクリプト名のセット
     let mut called: HashSet<&str> = HashSet::new();
 
-    // Perform Script ステップによる参照
+    // Perform Script ステップによる参照（無効ステップは除外）
     for script in &ddr.scripts {
         for step in &script.steps {
+            if !step.enabled {
+                continue;
+            }
             let Some(ref script_ref) = step.script_ref else {
                 continue;
             };
@@ -233,6 +236,108 @@ mod tests {
 
         let orphans = find_orphan_scripts(&ddr);
         assert!(!orphans.iter().any(|o| o.script_name == "OnLoad"));
+    }
+
+    /// ボタンが外部ファイルのスクリプトを参照していても、
+    /// 同名のローカルスクリプトは孤立と判定されるべき。
+    #[test]
+    fn external_button_ref_does_not_hide_local_orphan() {
+        // LocalScript は定義されているが、ボタンから呼ばれるのは外部ファイルの同名スクリプト。
+        // ローカルの LocalScript はどこからも呼ばれていないので孤立のはず。
+        const XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<FMPReport type="Report" version="21.0v1" creationDate="2024/01/01" creationTime="12:00:00">
+  <File name="TestDB">
+    <BaseTableCatalog/>
+    <RelationshipGraph><TableList/><RelationshipList/></RelationshipGraph>
+    <LayoutCatalog>
+      <Layout id="1" encryptionState="NotProtected" name="Main" tableOccurrenceName="Contact">
+        <ObjectList>
+          <Object type="Button" key="1" name="">
+            <Script name="LocalScript" file="OtherFile.fmp12"/>
+          </Object>
+        </ObjectList>
+      </Layout>
+    </LayoutCatalog>
+    <ScriptCatalog>
+      <Script id="1" name="LocalScript" runFullAccess="False" includeInMenu="False">
+        <StepList/>
+      </Script>
+    </ScriptCatalog>
+    <ValueListCatalog/>
+    <AccountCatalog/>
+    <PrivilegesCatalog/>
+    <ExtendedPrivilegeCatalog/>
+    <CustomFunctionCatalog/>
+    <Options/>
+  </File>
+</FMPReport>"#;
+        let ddr = crate::parser::parse_ddr(XML).unwrap();
+        let orphans = find_orphan_scripts(&ddr);
+        assert!(
+            orphans.iter().any(|o| o.script_name == "LocalScript"),
+            "外部ファイルの同名参照によって LocalScript が孤立から除外されてはいけない: {orphans:?}"
+        );
+    }
+
+    /// 無効化（disabled）された Perform Script ステップからのみ参照されるスクリプトは
+    /// 孤立と判定されるべき。
+    #[test]
+    fn disabled_perform_script_does_not_hide_orphan() {
+        use crate::parser::models::*;
+        use crate::parser::version::FmVersion;
+
+        let ddr = DdrFile {
+            file_name: "Test".into(),
+            fm_version: FmVersion {
+                major: 21,
+                minor: 0,
+                patch: "v1".into(),
+            },
+            tables: vec![],
+            scripts: vec![
+                Script {
+                    id: ScriptId(1),
+                    name: "Caller".into(),
+                    run_with_full_access: false,
+                    steps: vec![ScriptStep {
+                        step_id: 89,
+                        name: "Perform Script".into(),
+                        enabled: false, // ← 無効化されている
+                        script_ref: Some(ScriptRef {
+                            name: "OnlyCalledWhenDisabled".into(),
+                            file_name: "".into(),
+                        }),
+                        calculation: None,
+                        step_text: None,
+                        broken_field_table: None,
+                        has_broken_layout_ref: false,
+                    }],
+                },
+                Script {
+                    id: ScriptId(2),
+                    name: "OnlyCalledWhenDisabled".into(),
+                    run_with_full_access: false,
+                    steps: vec![],
+                },
+            ],
+            layouts: vec![],
+            relationships: vec![],
+            value_lists: vec![],
+            custom_functions: vec![],
+            accounts: vec![],
+            privilege_sets: vec![],
+            table_occurrences: vec![],
+            file_script_triggers: vec![],
+            external_data_sources: vec![],
+        };
+
+        let orphans = find_orphan_scripts(&ddr);
+        assert!(
+            orphans
+                .iter()
+                .any(|o| o.script_name == "OnlyCalledWhenDisabled"),
+            "無効ステップからのみ参照されるスクリプトは孤立と判定されるべき: {orphans:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/analyzer/report_card.rs
+++ b/src-tauri/src/analyzer/report_card.rs
@@ -92,7 +92,8 @@ pub fn generate_report_card(ddr: &DdrFile) -> ReportCard {
                 (Some("layout".into()), Some(r.source_name.clone()))
             }
             crate::analyzer::broken_refs::BrokenRefKind::BrokenFieldRef
-            | crate::analyzer::broken_refs::BrokenRefKind::BrokenLayoutRef => {
+            | crate::analyzer::broken_refs::BrokenRefKind::BrokenLayoutRef
+            | crate::analyzer::broken_refs::BrokenRefKind::UnknownRef => {
                 (Some("script".into()), Some(r.source_name.clone()))
             }
         };

--- a/src-tauri/src/analyzer/report_card.rs
+++ b/src-tauri/src/analyzer/report_card.rs
@@ -104,7 +104,7 @@ pub fn generate_report_card(ddr: &DdrFile) -> ReportCard {
             severity: Severity::Error,
             category: "broken_ref".into(),
             message: format!(
-                "[{:?}] '{}' references non-existent script '{}'",
+                "[{:?}] '{}' → '{}'",
                 r.kind, r.source_name, r.target_script_name
             ),
             element_kind,

--- a/src-tauri/src/analyzer/report_card.rs
+++ b/src-tauri/src/analyzer/report_card.rs
@@ -96,6 +96,9 @@ pub fn generate_report_card(ddr: &DdrFile) -> ReportCard {
             | crate::analyzer::broken_refs::BrokenRefKind::UnknownRef => {
                 (Some("script".into()), Some(r.source_name.clone()))
             }
+            crate::analyzer::broken_refs::BrokenRefKind::BrokenFieldPlacement => {
+                (Some("layout".into()), Some(r.source_name.clone()))
+            }
         };
         issues.push(ReportIssue {
             severity: Severity::Error,

--- a/src-tauri/src/commands/analysis.rs
+++ b/src-tauri/src/commands/analysis.rs
@@ -529,7 +529,9 @@ mod tests {
         let mut refs = find_broken_refs(&ddr);
         // コマンドと同じ ID 解決ロジックを適用
         for r in &mut refs {
-            let etype = if r.kind == BrokenRefKind::ScriptTrigger {
+            let etype = if r.kind == BrokenRefKind::ScriptTrigger
+                || r.kind == BrokenRefKind::BrokenFieldPlacement
+            {
                 "layout"
             } else {
                 "script"

--- a/src-tauri/src/commands/analysis.rs
+++ b/src-tauri/src/commands/analysis.rs
@@ -159,7 +159,9 @@ pub async fn get_broken_refs(
     let mut refs = find_broken_refs(&ddr);
     let db = super::lock_db(&state)?;
     for r in &mut refs {
-        let etype = if r.kind == BrokenRefKind::ScriptTrigger {
+        let etype = if r.kind == BrokenRefKind::ScriptTrigger
+            || r.kind == BrokenRefKind::BrokenFieldPlacement
+        {
             "layout"
         } else {
             "script"

--- a/src-tauri/src/commands/analysis.rs
+++ b/src-tauri/src/commands/analysis.rs
@@ -1,11 +1,11 @@
-﻿//! プロジェクト管理・サマリー取得コマンド。
+//! プロジェクト管理・サマリー取得コマンド。
 
 use rusqlite::{params, OptionalExtension as _};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     analyzer::{
-        broken_refs::{find_broken_refs, BrokenRef},
+        broken_refs::{find_broken_refs, BrokenRef, BrokenRefKind},
         report_card::{generate_report_card, ReportCard},
     },
     commands::CommandError,
@@ -156,7 +156,21 @@ pub async fn get_broken_refs(
     project_id: i64,
 ) -> Result<Vec<BrokenRef>, CommandError> {
     let ddr = get_ddr(&state, project_id)?;
-    Ok(find_broken_refs(&ddr))
+    let mut refs = find_broken_refs(&ddr);
+    let db = super::lock_db(&state)?;
+    for r in &mut refs {
+        let etype = if r.kind == BrokenRefKind::ScriptTrigger {
+            "layout"
+        } else {
+            "script"
+        };
+        if let Ok(Some(elem)) =
+            resolve_element_by_name_inner(&db.conn, project_id, etype, &r.source_name)
+        {
+            r.source_id = Some(elem.id);
+        }
+    }
+    Ok(refs)
 }
 
 /// プロジェクトの健全性レポートを返す。
@@ -500,5 +514,34 @@ mod tests {
         insert_ddr_file(&mut db, &ddr, sid, Some("Second")).unwrap();
         let summaries = list_solution_project_summaries_inner(&db, sid).unwrap();
         assert_eq!(summaries.len(), 2);
+    }
+
+    // ---- get_broken_refs の source_id 解決テスト ----
+
+    #[test]
+    fn get_broken_refs_resolves_source_id_from_db() {
+        use super::resolve_element_by_name_inner;
+        use crate::analyzer::broken_refs::{find_broken_refs, BrokenRefKind};
+        let (db, pid) = setup();
+        let ddr = parse_ddr(MINIMAL_XML).unwrap();
+        let mut refs = find_broken_refs(&ddr);
+        // コマンドと同じ ID 解決ロジックを適用
+        for r in &mut refs {
+            let etype = if r.kind == BrokenRefKind::ScriptTrigger {
+                "layout"
+            } else {
+                "script"
+            };
+            if let Ok(Some(elem)) =
+                resolve_element_by_name_inner(&db.conn, pid, etype, &r.source_name)
+            {
+                r.source_id = Some(elem.id);
+            }
+        }
+        assert!(!refs.is_empty(), "minimal.xml は壊れた参照を含むこと");
+        assert!(
+            refs.iter().any(|r| r.source_id.is_some()),
+            "少なくとも 1 件の broken ref は source_id が DB から解決されること"
+        );
     }
 }

--- a/src-tauri/src/parser/layout_parser/object_scanner.rs
+++ b/src-tauri/src/parser/layout_parser/object_scanner.rs
@@ -223,26 +223,35 @@ pub(super) fn scan_object<R: BufRead>(
 
             // ---- Script (self-closing) ----
             Event::Empty(ref e) if e.name().as_ref() == b"Script" => {
-                if let Ok(name) = get_attr(e, b"name") {
-                    if !name.is_empty() {
-                        button_scripts.push(name);
+                let file = get_attr(e, b"file").unwrap_or_default();
+                if file.is_empty() {
+                    if let Ok(name) = get_attr(e, b"name") {
+                        if !name.is_empty() {
+                            button_scripts.push(name);
+                        }
                     }
                 }
             }
             // ---- Script (with children) ----
             Event::Start(ref e) if e.name().as_ref() == b"Script" => {
-                if let Ok(name) = get_attr(e, b"name") {
-                    if !name.is_empty() {
-                        button_scripts.push(name);
+                let file = get_attr(e, b"file").unwrap_or_default();
+                if file.is_empty() {
+                    if let Ok(name) = get_attr(e, b"name") {
+                        if !name.is_empty() {
+                            button_scripts.push(name);
+                        }
                     }
                 }
                 skip_element(reader, buf)?;
             }
             // ---- ScriptReference (self-closing) ----
             Event::Empty(ref e) if e.name().as_ref() == b"ScriptReference" => {
-                if let Ok(name) = get_attr(e, b"name") {
-                    if !name.is_empty() {
-                        button_scripts.push(name);
+                let file = get_attr(e, b"file").unwrap_or_default();
+                if file.is_empty() {
+                    if let Ok(name) = get_attr(e, b"name") {
+                        if !name.is_empty() {
+                            button_scripts.push(name);
+                        }
                     }
                 }
             }

--- a/src/__tests__/BrokenRefsList.test.tsx
+++ b/src/__tests__/BrokenRefsList.test.tsx
@@ -137,9 +137,9 @@ describe("BrokenRefsList", () => {
   });
 
   it("broken_field_placement_shows_label", () => {
-    const refs = [
-      { kind: "brokenFieldPlacement" as const, source_name: "CustomerLayout", source_id: 20, target_script_name: "(フィールド削除済み) #7" },
-    ] as Parameters<typeof useBrokenRefs>[0] extends never ? never : BrokenRef[];
+    const refs: BrokenRef[] = [
+      { kind: "brokenFieldPlacement", source_name: "CustomerLayout", source_id: 20, target_script_name: "(フィールド削除済み) #7" },
+    ];
     vi.mocked(useBrokenRefs).mockReturnValue(
       { data: refs as BrokenRef[], isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
     );

--- a/src/__tests__/BrokenRefsList.test.tsx
+++ b/src/__tests__/BrokenRefsList.test.tsx
@@ -1,32 +1,18 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { BrokenRefsList } from "../components/BrokenRefsList";
-import { makeScriptRow, makeLayoutRow } from "./testFixtures";
 import type { BrokenRef } from "../types/ddr";
 
 vi.mock("../hooks/analysis", () => ({
   useBrokenRefs: vi.fn(),
-}));
-vi.mock("../hooks/script", () => ({
-  useScriptList: vi.fn(),
-}));
-vi.mock("../hooks/layout", () => ({
-  useLayoutList: vi.fn(),
 }));
 vi.mock("../stores/appStore", () => ({
   useAppStore: vi.fn(),
 }));
 
 import { useBrokenRefs } from "../hooks/analysis";
-import { useScriptList } from "../hooks/script";
-import { useLayoutList } from "../hooks/layout";
 import { useAppStore } from "../stores/appStore";
 
-const mockScripts = [
-  makeScriptRow({ id: 1, name: "MainScript" }),
-  makeScriptRow({ id: 2, name: "NavScript" }),
-];
-const mockLayouts = [makeLayoutRow({ id: 10, name: "CustomerList" })];
 const mockSelectElement = vi.fn();
 
 beforeEach(() => {
@@ -34,12 +20,6 @@ beforeEach(() => {
   vi.mocked(useAppStore).mockReturnValue({
     selectElement: mockSelectElement,
   } as unknown as ReturnType<typeof useAppStore>);
-  vi.mocked(useScriptList).mockReturnValue(
-    { data: mockScripts, isLoading: false } as unknown as ReturnType<typeof useScriptList>
-  );
-  vi.mocked(useLayoutList).mockReturnValue(
-    { data: mockLayouts, isLoading: false } as unknown as ReturnType<typeof useLayoutList>
-  );
 });
 
 describe("BrokenRefsList", () => {
@@ -73,6 +53,7 @@ describe("BrokenRefsList", () => {
       { kind: "scriptTrigger",   source_name: "CustomerList", target_script_name: "Missing" },
       { kind: "brokenFieldRef",  source_name: "MainScript",   target_script_name: "Set Field [...]" },
       { kind: "brokenLayoutRef", source_name: "NavScript",    target_script_name: "Go to Layout [...]" },
+      { kind: "unknownRef",      source_name: "OtherScript",  target_script_name: "ファイルを開く [<不明>]" },
     ];
     vi.mocked(useBrokenRefs).mockReturnValue(
       { data: refs, isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
@@ -82,11 +63,12 @@ describe("BrokenRefsList", () => {
     expect(screen.getByText("Script Trigger")).toBeInTheDocument();
     expect(screen.getByText("壊れたフィールド参照")).toBeInTheDocument();
     expect(screen.getByText("壊れたレイアウト参照")).toBeInTheDocument();
+    expect(screen.getByText("参照先不明")).toBeInTheDocument();
   });
 
   it("perform_script_click_selects_script", () => {
     const refs: BrokenRef[] = [
-      { kind: "performScript", source_name: "MainScript", target_script_name: "Missing" },
+      { kind: "performScript", source_name: "MainScript", source_id: 1, target_script_name: "Missing" },
     ];
     vi.mocked(useBrokenRefs).mockReturnValue(
       { data: refs, isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
@@ -100,7 +82,7 @@ describe("BrokenRefsList", () => {
 
   it("script_trigger_click_selects_layout", () => {
     const refs: BrokenRef[] = [
-      { kind: "scriptTrigger", source_name: "CustomerList", target_script_name: "Missing" },
+      { kind: "scriptTrigger", source_name: "CustomerList", source_id: 10, target_script_name: "Missing" },
     ];
     vi.mocked(useBrokenRefs).mockReturnValue(
       { data: refs, isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
@@ -114,7 +96,7 @@ describe("BrokenRefsList", () => {
 
   it("broken_field_ref_click_selects_script", () => {
     const refs: BrokenRef[] = [
-      { kind: "brokenFieldRef", source_name: "MainScript", target_script_name: "Set Field [...]" },
+      { kind: "brokenFieldRef", source_name: "MainScript", source_id: 1, target_script_name: "Set Field [...]" },
     ];
     vi.mocked(useBrokenRefs).mockReturnValue(
       { data: refs, isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
@@ -128,7 +110,7 @@ describe("BrokenRefsList", () => {
 
   it("broken_layout_ref_click_selects_script", () => {
     const refs: BrokenRef[] = [
-      { kind: "brokenLayoutRef", source_name: "NavScript", target_script_name: "Go to Layout [...]" },
+      { kind: "brokenLayoutRef", source_name: "NavScript", source_id: 2, target_script_name: "Go to Layout [...]" },
     ];
     vi.mocked(useBrokenRefs).mockReturnValue(
       { data: refs, isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
@@ -138,5 +120,31 @@ describe("BrokenRefsList", () => {
     expect(mockSelectElement).toHaveBeenCalledWith({
       kind: "script", projectId: 1, id: 2, name: "NavScript",
     });
+  });
+
+  it("unknown_ref_click_selects_script", () => {
+    const refs: BrokenRef[] = [
+      { kind: "unknownRef", source_name: "OtherScript", source_id: 5, target_script_name: "ファイルを開く [<不明>]" },
+    ];
+    vi.mocked(useBrokenRefs).mockReturnValue(
+      { data: refs, isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
+    );
+    render(<BrokenRefsList projectId={1} />);
+    fireEvent.click(screen.getByTitle("OtherScript を表示"));
+    expect(mockSelectElement).toHaveBeenCalledWith({
+      kind: "script", projectId: 1, id: 5, name: "OtherScript",
+    });
+  });
+
+  it("click_does_nothing_when_source_id_is_null", () => {
+    const refs: BrokenRef[] = [
+      { kind: "performScript", source_name: "MainScript", target_script_name: "Missing" },
+    ];
+    vi.mocked(useBrokenRefs).mockReturnValue(
+      { data: refs, isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
+    );
+    render(<BrokenRefsList projectId={1} />);
+    fireEvent.click(screen.getByTitle("MainScript を表示"));
+    expect(mockSelectElement).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/BrokenRefsList.test.tsx
+++ b/src/__tests__/BrokenRefsList.test.tsx
@@ -169,7 +169,19 @@ describe("BrokenRefsList", () => {
       { data: refs, isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
     );
     render(<BrokenRefsList projectId={1} />);
-    fireEvent.click(screen.getByTitle("MainScript を表示"));
+    fireEvent.click(screen.getByRole("button", { name: /MainScript/ }));
     expect(mockSelectElement).not.toHaveBeenCalled();
+  });
+
+  it("button_is_disabled_when_source_id_is_null", () => {
+    const refs: BrokenRef[] = [
+      { kind: "performScript", source_name: "MainScript", target_script_name: "Missing" },
+    ];
+    vi.mocked(useBrokenRefs).mockReturnValue(
+      { data: refs, isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
+    );
+    render(<BrokenRefsList projectId={1} />);
+    const btn = screen.getByRole("button", { name: /MainScript/ });
+    expect(btn).toBeDisabled();
   });
 });

--- a/src/__tests__/BrokenRefsList.test.tsx
+++ b/src/__tests__/BrokenRefsList.test.tsx
@@ -136,6 +136,31 @@ describe("BrokenRefsList", () => {
     });
   });
 
+  it("broken_field_placement_shows_label", () => {
+    const refs = [
+      { kind: "brokenFieldPlacement" as const, source_name: "CustomerLayout", source_id: 20, target_script_name: "(フィールド削除済み) #7" },
+    ] as Parameters<typeof useBrokenRefs>[0] extends never ? never : BrokenRef[];
+    vi.mocked(useBrokenRefs).mockReturnValue(
+      { data: refs as BrokenRef[], isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
+    );
+    render(<BrokenRefsList projectId={1} />);
+    expect(screen.getByText("レイアウト上の削除フィールド")).toBeInTheDocument();
+  });
+
+  it("broken_field_placement_click_selects_layout", () => {
+    const refs = [
+      { kind: "brokenFieldPlacement" as const, source_name: "CustomerLayout", source_id: 20, target_script_name: "(フィールド削除済み) #7" },
+    ] as BrokenRef[];
+    vi.mocked(useBrokenRefs).mockReturnValue(
+      { data: refs, isLoading: false } as unknown as ReturnType<typeof useBrokenRefs>
+    );
+    render(<BrokenRefsList projectId={1} />);
+    fireEvent.click(screen.getByTitle("CustomerLayout を表示"));
+    expect(mockSelectElement).toHaveBeenCalledWith({
+      kind: "layout", projectId: 1, id: 20, name: "CustomerLayout",
+    });
+  });
+
   it("click_does_nothing_when_source_id_is_null", () => {
     const refs: BrokenRef[] = [
       { kind: "performScript", source_name: "MainScript", target_script_name: "Missing" },

--- a/src/__tests__/detail/LayoutDetail.test.tsx
+++ b/src/__tests__/detail/LayoutDetail.test.tsx
@@ -107,6 +107,31 @@ describe("LayoutDetail", () => {
     });
   });
 
+  it("broken_field_placement_row_has_red_background", () => {
+    vi.mocked(useLayoutTriggers).mockReturnValue(
+      { data: [], isLoading: false } as unknown as ReturnType<typeof useLayoutTriggers>
+    );
+    vi.mocked(useLayoutObjects).mockReturnValue({
+      data: [makeLayoutObjectRow({ id: 10, object_key: 7, object_type: "Field", field_table_occurrence: "", field_name: "" })],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useLayoutObjects>);
+    render(<LayoutDetail layout={mockLayout} projectId={1} />);
+    const row = screen.getByText("Field").closest("tr")!;
+    expect(row.className).toMatch(/bg-red-50/);
+  });
+
+  it("broken_field_placement_shows_deleted_label_in_field_column", () => {
+    vi.mocked(useLayoutTriggers).mockReturnValue(
+      { data: [], isLoading: false } as unknown as ReturnType<typeof useLayoutTriggers>
+    );
+    vi.mocked(useLayoutObjects).mockReturnValue({
+      data: [makeLayoutObjectRow({ id: 10, object_key: 7, object_type: "Field", field_table_occurrence: "", field_name: "" })],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useLayoutObjects>);
+    render(<LayoutDetail layout={mockLayout} projectId={1} />);
+    expect(screen.getByText(/(削除済み).*#7/)).toBeInTheDocument();
+  });
+
   it("diff_context_shows_added_badge_for_new_object", () => {
     const newObj = makeLayoutObjectRow({ id: 1, object_key: 1, object_type: "Field" });
     vi.mocked(useAppStore).mockReturnValue({

--- a/src/__tests__/detail/UpgradeCheckPanel.test.tsx
+++ b/src/__tests__/detail/UpgradeCheckPanel.test.tsx
@@ -78,6 +78,7 @@ const mockBrokenRefs: BrokenRefWithProject[] = [
   {
     kind: "performScript",
     source_name: "MainScript",
+    source_id: 5,
     target_script_name: "DeletedScript",
     project_id: 1,
     project_name: "DB_A",
@@ -85,6 +86,7 @@ const mockBrokenRefs: BrokenRefWithProject[] = [
   {
     kind: "scriptTrigger",
     source_name: "Layout1",
+    source_id: 15,
     target_script_name: "MissingScript",
     project_id: 2,
     project_name: "DB_B",
@@ -230,6 +232,48 @@ describe("壊れた参照セクション", () => {
     await user.click(screen.getByRole("button", { name: /壊れた参照/ }));
     expect(screen.getByText("MainScript")).toBeInTheDocument();
     expect(screen.getByText("DeletedScript")).toBeInTheDocument();
+  });
+
+  it("broken_ref_performscript_click_selects_script", async () => {
+    const selectElement = vi.fn();
+    vi.mocked(useAppStore).mockImplementation(() => ({
+      checkItems: [],
+      showBrokenRefsInUpgradeCheck: true,
+      selectElement,
+      setRightPanel: vi.fn(),
+    } as unknown as ReturnType<typeof useAppStore>));
+    const user = userEvent.setup();
+    render(<UpgradeCheckPanel solutionId={1} />);
+    await user.click(screen.getByRole("button", { name: /壊れた参照/ }));
+    // MainScript の行をクリック
+    await user.click(screen.getByRole("button", { name: /MainScript/ }));
+    expect(selectElement).toHaveBeenCalledWith({
+      kind: "script",
+      projectId: 1,
+      id: 5,
+      name: "MainScript",
+    });
+  });
+
+  it("broken_ref_script_trigger_click_selects_layout", async () => {
+    const selectElement = vi.fn();
+    vi.mocked(useAppStore).mockImplementation(() => ({
+      checkItems: [],
+      showBrokenRefsInUpgradeCheck: true,
+      selectElement,
+      setRightPanel: vi.fn(),
+    } as unknown as ReturnType<typeof useAppStore>));
+    const user = userEvent.setup();
+    render(<UpgradeCheckPanel solutionId={1} />);
+    await user.click(screen.getByRole("button", { name: /壊れた参照/ }));
+    // Layout1 の行をクリック
+    await user.click(screen.getByRole("button", { name: /Layout1/ }));
+    expect(selectElement).toHaveBeenCalledWith({
+      kind: "layout",
+      projectId: 2,
+      id: 15,
+      name: "Layout1",
+    });
   });
 
   it("broken_refs_shows_loading_indicator", async () => {

--- a/src/__tests__/detail/UpgradeCheckPanel.test.tsx
+++ b/src/__tests__/detail/UpgradeCheckPanel.test.tsx
@@ -276,6 +276,40 @@ describe("壊れた参照セクション", () => {
     });
   });
 
+  it("broken_field_placement_click_selects_layout", async () => {
+    const selectElement = vi.fn();
+    const refsWithPlacement: BrokenRefWithProject[] = [
+      ...mockBrokenRefs,
+      {
+        kind: "brokenFieldPlacement" as BrokenRefWithProject["kind"],
+        source_name: "CustomerLayout",
+        source_id: 30,
+        target_script_name: "(フィールド削除済み) #7",
+        project_id: 1,
+        project_name: "DB_A",
+      },
+    ];
+    vi.mocked(useSolutionBrokenRefs).mockReturnValue(
+      { data: refsWithPlacement, isLoading: false } as unknown as ReturnType<typeof useSolutionBrokenRefs>
+    );
+    vi.mocked(useAppStore).mockImplementation(() => ({
+      checkItems: [],
+      showBrokenRefsInUpgradeCheck: true,
+      selectElement,
+      setRightPanel: vi.fn(),
+    } as unknown as ReturnType<typeof useAppStore>));
+    const user = userEvent.setup();
+    render(<UpgradeCheckPanel solutionId={1} />);
+    await user.click(screen.getByRole("button", { name: /壊れた参照/ }));
+    await user.click(screen.getByRole("button", { name: /CustomerLayout/ }));
+    expect(selectElement).toHaveBeenCalledWith({
+      kind: "layout",
+      projectId: 1,
+      id: 30,
+      name: "CustomerLayout",
+    });
+  });
+
   it("broken_refs_shows_loading_indicator", async () => {
     vi.mocked(useSolutionBrokenRefs).mockReturnValue(
       { data: undefined, isLoading: true } as unknown as ReturnType<typeof useSolutionBrokenRefs>

--- a/src/__tests__/detail/UpgradeCheckPanel.test.tsx
+++ b/src/__tests__/detail/UpgradeCheckPanel.test.tsx
@@ -74,6 +74,23 @@ const mockHits: UpgradeHit[] = [
   },
 ];
 
+const mockBrokenRefs: BrokenRefWithProject[] = [
+  {
+    kind: "performScript",
+    source_name: "MainScript",
+    target_script_name: "DeletedScript",
+    project_id: 1,
+    project_name: "DB_A",
+  },
+  {
+    kind: "scriptTrigger",
+    source_name: "Layout1",
+    target_script_name: "MissingScript",
+    project_id: 2,
+    project_name: "DB_B",
+  },
+];
+
 describe("UpgradeCheckPanel", () => {
   it("shows_group_header_with_count", () => {
     vi.mocked(useUpgradeCheck).mockReturnValue(
@@ -170,23 +187,6 @@ describe("UpgradeCheckPanel", () => {
   });
 });
 
-const mockBrokenRefs: BrokenRefWithProject[] = [
-  {
-    kind: "performScript",
-    source_name: "MainScript",
-    target_script_name: "DeletedScript",
-    project_id: 1,
-    project_name: "DB_A",
-  },
-  {
-    kind: "scriptTrigger",
-    source_name: "Layout1",
-    target_script_name: "MissingScript",
-    project_id: 2,
-    project_name: "DB_B",
-  },
-];
-
 describe("壊れた参照セクション", () => {
   beforeEach(() => {
     vi.mocked(useSolutionBrokenRefs).mockReturnValue(
@@ -230,5 +230,16 @@ describe("壊れた参照セクション", () => {
     await user.click(screen.getByRole("button", { name: /壊れた参照/ }));
     expect(screen.getByText("MainScript")).toBeInTheDocument();
     expect(screen.getByText("DeletedScript")).toBeInTheDocument();
+  });
+
+  it("broken_refs_shows_loading_indicator", async () => {
+    vi.mocked(useSolutionBrokenRefs).mockReturnValue(
+      { data: undefined, isLoading: true } as unknown as ReturnType<typeof useSolutionBrokenRefs>
+    );
+    const user = userEvent.setup();
+    render(<UpgradeCheckPanel solutionId={1} />);
+    expect(screen.getByText("…")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /壊れた参照/ }));
+    expect(document.querySelector(".animate-spin")).toBeInTheDocument();
   });
 });

--- a/src/__tests__/detail/UpgradeCheckPanel.test.tsx
+++ b/src/__tests__/detail/UpgradeCheckPanel.test.tsx
@@ -1,11 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { UpgradeCheckPanel } from "../../components/detail/UpgradeCheckPanel";
-import type { UpgradeHit } from "../../types/ddr";
+import type { BrokenRefWithProject, UpgradeHit } from "../../types/ddr";
 
 vi.mock("../../hooks/analysis", () => ({
   useUpgradeCheck: vi.fn(),
+  useSolutionBrokenRefs: vi.fn(),
 }));
 
 vi.mock("../../stores/appStore", () => ({
@@ -13,6 +14,7 @@ vi.mock("../../stores/appStore", () => ({
     checkItems: [
       { id: "item1", label: "Perform Script", enabled: true, detectionType: "step_type_id", detectionValue: "89" },
     ],
+    showBrokenRefsInUpgradeCheck: false,
     selectElement: vi.fn(),
     setRightPanel: vi.fn(),
   })),
@@ -22,7 +24,22 @@ vi.mock("../../stores/appStore", () => ({
 vi.mock("@tauri-apps/plugin-dialog", () => ({ save: vi.fn().mockResolvedValue(null) }));
 vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
 
-import { useUpgradeCheck } from "../../hooks/analysis";
+import { useUpgradeCheck, useSolutionBrokenRefs } from "../../hooks/analysis";
+import { useAppStore } from "../../stores/appStore";
+
+beforeEach(() => {
+  vi.mocked(useAppStore).mockImplementation(() => ({
+    checkItems: [
+      { id: "item1", label: "Perform Script", enabled: true, detectionType: "step_type_id", detectionValue: "89" },
+    ],
+    showBrokenRefsInUpgradeCheck: false,
+    selectElement: vi.fn(),
+    setRightPanel: vi.fn(),
+  } as unknown as ReturnType<typeof useAppStore>));
+  vi.mocked(useSolutionBrokenRefs).mockReturnValue(
+    { data: [], isLoading: false } as unknown as ReturnType<typeof useSolutionBrokenRefs>
+  );
+});
 
 const mockHits: UpgradeHit[] = [
   {
@@ -128,14 +145,14 @@ describe("UpgradeCheckPanel", () => {
 
   it("click_script_hit_calls_selectElement", async () => {
     const selectElement = vi.fn();
-    const { useAppStore } = await import("../../stores/appStore");
-    vi.mocked(useAppStore).mockReturnValue({
+    vi.mocked(useAppStore).mockImplementation(() => ({
       checkItems: [
         { id: "item1", label: "Perform Script", enabled: true, detectionType: "step_type_id", detectionValue: "89" },
       ],
+      showBrokenRefsInUpgradeCheck: false,
       selectElement,
       setRightPanel: vi.fn(),
-    } as unknown as ReturnType<typeof useAppStore>);
+    } as unknown as ReturnType<typeof useAppStore>));
     vi.mocked(useUpgradeCheck).mockReturnValue(
       { data: mockHits, isLoading: false } as unknown as ReturnType<typeof useUpgradeCheck>
     );
@@ -150,5 +167,68 @@ describe("UpgradeCheckPanel", () => {
       id: 10,
       name: "Script A",
     });
+  });
+});
+
+const mockBrokenRefs: BrokenRefWithProject[] = [
+  {
+    kind: "performScript",
+    source_name: "MainScript",
+    target_script_name: "DeletedScript",
+    project_id: 1,
+    project_name: "DB_A",
+  },
+  {
+    kind: "scriptTrigger",
+    source_name: "Layout1",
+    target_script_name: "MissingScript",
+    project_id: 2,
+    project_name: "DB_B",
+  },
+];
+
+describe("壊れた参照セクション", () => {
+  beforeEach(() => {
+    vi.mocked(useSolutionBrokenRefs).mockReturnValue(
+      { data: mockBrokenRefs, isLoading: false } as unknown as ReturnType<typeof useSolutionBrokenRefs>
+    );
+    vi.mocked(useAppStore).mockImplementation(() => ({
+      checkItems: [],
+      showBrokenRefsInUpgradeCheck: true,
+      selectElement: vi.fn(),
+      setRightPanel: vi.fn(),
+    } as unknown as ReturnType<typeof useAppStore>));
+    vi.mocked(useUpgradeCheck).mockReturnValue(
+      { data: [], isLoading: false } as unknown as ReturnType<typeof useUpgradeCheck>
+    );
+  });
+
+  it("broken_refs_section_shown_when_enabled", () => {
+    render(<UpgradeCheckPanel solutionId={1} />);
+    expect(screen.getByRole("button", { name: /壊れた参照/ })).toBeInTheDocument();
+  });
+
+  it("broken_refs_section_hidden_when_disabled", () => {
+    vi.mocked(useAppStore).mockImplementation(() => ({
+      checkItems: [],
+      showBrokenRefsInUpgradeCheck: false,
+      selectElement: vi.fn(),
+      setRightPanel: vi.fn(),
+    } as unknown as ReturnType<typeof useAppStore>));
+    render(<UpgradeCheckPanel solutionId={1} />);
+    expect(screen.queryByRole("button", { name: /壊れた参照/ })).not.toBeInTheDocument();
+  });
+
+  it("broken_refs_section_shows_count", () => {
+    render(<UpgradeCheckPanel solutionId={1} />);
+    expect(screen.getByText("2 件")).toBeInTheDocument();
+  });
+
+  it("broken_refs_section_expands_on_click", async () => {
+    const user = userEvent.setup();
+    render(<UpgradeCheckPanel solutionId={1} />);
+    await user.click(screen.getByRole("button", { name: /壊れた参照/ }));
+    expect(screen.getByText("MainScript")).toBeInTheDocument();
+    expect(screen.getByText("DeletedScript")).toBeInTheDocument();
   });
 });

--- a/src/__tests__/detail/UpgradeSettingsPanel.test.tsx
+++ b/src/__tests__/detail/UpgradeSettingsPanel.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UpgradeSettingsPanel } from "../../components/detail/UpgradeSettingsPanel";
+
+vi.mock("../../stores/appStore", () => ({
+  useAppStore: vi.fn(),
+}));
+
+import { useAppStore } from "../../stores/appStore";
+
+const baseStore = {
+  checkItems: [],
+  setCheckItems: vi.fn(),
+  showBrokenRefsInUpgradeCheck: true,
+  setShowBrokenRefsInUpgradeCheck: vi.fn(),
+};
+
+describe("UpgradeSettingsPanel - 解析セクション", () => {
+  it("broken_refs_toggle_is_checked_when_enabled", () => {
+    vi.mocked(useAppStore).mockImplementation(
+      () => ({ ...baseStore } as unknown as ReturnType<typeof useAppStore>)
+    );
+    render(<UpgradeSettingsPanel onClose={vi.fn()} />);
+    const checkbox = screen.getByRole("checkbox", { name: /壊れた参照/ });
+    expect(checkbox).toBeChecked();
+  });
+
+  it("broken_refs_toggle_calls_setter_with_false", async () => {
+    const setShowBrokenRefsInUpgradeCheck = vi.fn();
+    vi.mocked(useAppStore).mockImplementation(
+      () => ({ ...baseStore, setShowBrokenRefsInUpgradeCheck } as unknown as ReturnType<typeof useAppStore>)
+    );
+    const user = userEvent.setup();
+    render(<UpgradeSettingsPanel onClose={vi.fn()} />);
+    await user.click(screen.getByRole("checkbox", { name: /壊れた参照/ }));
+    expect(setShowBrokenRefsInUpgradeCheck).toHaveBeenCalledWith(false);
+  });
+
+  it("broken_refs_toggle_is_unchecked_when_disabled", () => {
+    vi.mocked(useAppStore).mockImplementation(
+      () => ({ ...baseStore, showBrokenRefsInUpgradeCheck: false } as unknown as ReturnType<typeof useAppStore>)
+    );
+    render(<UpgradeSettingsPanel onClose={vi.fn()} />);
+    const checkbox = screen.getByRole("checkbox", { name: /壊れた参照/ });
+    expect(checkbox).not.toBeChecked();
+  });
+});

--- a/src/components/BrokenRefsList.tsx
+++ b/src/components/BrokenRefsList.tsx
@@ -55,7 +55,8 @@ export function BrokenRefsList({ projectId }: Props) {
             <button
               className={`${LIST_ROW} rounded`}
               onClick={() => handleClick(ref)}
-              title={`${ref.source_name} を表示`}
+              disabled={ref.source_id == null}
+              title={ref.source_id != null ? `${ref.source_name} を表示` : undefined}
             >
               <span className={`mr-2 ${BADGE_VARIANTS.gray}`}>{KIND_LABELS[ref.kind] ?? ref.kind}</span>
               <span className="text-gray-700">{ref.source_name}</span>

--- a/src/components/BrokenRefsList.tsx
+++ b/src/components/BrokenRefsList.tsx
@@ -8,7 +8,7 @@ interface Props {
   projectId: number | null;
 }
 
-const KIND_LABELS: Record<string, string> = {
+const KIND_LABELS: Record<BrokenRef["kind"], string> = {
   performScript: "Perform Script",
   scriptTrigger: "Script Trigger",
   brokenFieldRef: "壊れたフィールド参照",
@@ -53,7 +53,7 @@ export function BrokenRefsList({ projectId }: Props) {
         {brokenRefs.map((ref, idx) => (
           <li key={idx}>
             <button
-              className={`${LIST_ROW} rounded`}
+              className={`${LIST_ROW} rounded disabled:opacity-40 disabled:cursor-not-allowed`}
               onClick={() => handleClick(ref)}
               disabled={ref.source_id == null}
               title={ref.source_id != null ? `${ref.source_name} を表示` : undefined}

--- a/src/components/BrokenRefsList.tsx
+++ b/src/components/BrokenRefsList.tsx
@@ -1,6 +1,4 @@
 import { useBrokenRefs } from "../hooks/analysis";
-import { useScriptList } from "../hooks/script";
-import { useLayoutList } from "../hooks/layout";
 import { useAppStore } from "../stores/appStore";
 import type { BrokenRef } from "../types/ddr";
 import { BADGE_VARIANTS, LIST_ROW } from "../styles/tokens";
@@ -15,12 +13,11 @@ const KIND_LABELS: Record<string, string> = {
   scriptTrigger: "Script Trigger",
   brokenFieldRef: "壊れたフィールド参照",
   brokenLayoutRef: "壊れたレイアウト参照",
+  unknownRef: "参照先不明",
 };
 
 export function BrokenRefsList({ projectId }: Props) {
   const { data: brokenRefs, isLoading } = useBrokenRefs(projectId);
-  const { data: scripts = [] } = useScriptList(projectId);
-  const { data: layouts = [] } = useLayoutList(projectId);
   const { selectElement } = useAppStore();
 
   if (projectId === null) return null;
@@ -36,14 +33,13 @@ export function BrokenRefsList({ projectId }: Props) {
   }
 
   function handleClick(ref: BrokenRef) {
-    if (!projectId) return;
-    if (ref.kind === "performScript" || ref.kind === "brokenFieldRef" || ref.kind === "brokenLayoutRef") {
-      const script = scripts.find((s) => s.name === ref.source_name);
-      if (script) selectElement({ kind: "script", projectId, id: script.id, name: script.name });
-    } else if (ref.kind === "scriptTrigger") {
-      const layout = layouts.find((l) => l.name === ref.source_name);
-      if (layout) selectElement({ kind: "layout", projectId, id: layout.id, name: layout.name });
-    }
+    if (!projectId || ref.source_id == null) return;
+    selectElement({
+      kind: ref.kind === "scriptTrigger" ? "layout" : "script",
+      projectId,
+      id: ref.source_id,
+      name: ref.source_name,
+    });
   }
 
   return (

--- a/src/components/BrokenRefsList.tsx
+++ b/src/components/BrokenRefsList.tsx
@@ -14,6 +14,7 @@ const KIND_LABELS: Record<string, string> = {
   brokenFieldRef: "壊れたフィールド参照",
   brokenLayoutRef: "壊れたレイアウト参照",
   unknownRef: "参照先不明",
+  brokenFieldPlacement: "レイアウト上の削除フィールド",
 };
 
 export function BrokenRefsList({ projectId }: Props) {
@@ -35,7 +36,7 @@ export function BrokenRefsList({ projectId }: Props) {
   function handleClick(ref: BrokenRef) {
     if (!projectId || ref.source_id == null) return;
     selectElement({
-      kind: ref.kind === "scriptTrigger" ? "layout" : "script",
+      kind: (ref.kind === "scriptTrigger" || ref.kind === "brokenFieldPlacement") ? "layout" : "script",
       projectId,
       id: ref.source_id,
       name: ref.source_name,

--- a/src/components/detail/LayoutDetail.tsx
+++ b/src/components/detail/LayoutDetail.tsx
@@ -215,9 +215,14 @@ export function LayoutDetail({ layout, projectId }: Props) {
                 !obj.isPhantom &&
                 rightPanel?.kind === "layout_object" &&
                 rightPanel.layoutObjectId === obj.id;
+              const isBrokenField =
+                obj.object_type === "Field" &&
+                (obj.field_table_occurrence === "" || obj.field_name === "");
               const dk = obj.diffKind;
               const rowBg = dk
                 ? DIFF_ROW_BG[dk]
+                : isBrokenField
+                ? "bg-red-50"
                 : isSelected
                 ? "bg-blue-100 text-blue-800"
                 : "hover:bg-blue-50";
@@ -245,7 +250,9 @@ export function LayoutDetail({ layout, projectId }: Props) {
                     {obj.button_label ?? <span className="text-gray-300">—</span>}
                   </td>
                   <td className={`px-3 py-2 border border-gray-200 ${textClass}`}>
-                    {obj.field_table_occurrence && obj.field_name
+                    {isBrokenField
+                      ? <span className="text-red-500 text-xs">(削除済み) #{obj.object_key}</span>
+                      : obj.field_table_occurrence && obj.field_name
                       ? `${obj.field_table_occurrence}::${obj.field_name}`
                       : <span className="text-gray-400">—</span>}
                   </td>

--- a/src/components/detail/UpgradeCheckPanel.tsx
+++ b/src/components/detail/UpgradeCheckPanel.tsx
@@ -54,6 +54,7 @@ const BROKEN_REF_KIND_LABEL: Record<BrokenRefWithProject["kind"], string> = {
   brokenFieldRef: "フィールド参照",
   brokenLayoutRef: "レイアウト参照",
   unknownRef: "参照先不明",
+  brokenFieldPlacement: "レイアウト上の削除フィールド",
 };
 
 export function UpgradeCheckPanel({ solutionId }: Props) {
@@ -113,7 +114,7 @@ export function UpgradeCheckPanel({ solutionId }: Props) {
   function handleBrokenRefClick(ref: BrokenRefWithProject) {
     if (ref.source_id == null) return;
     selectElement({
-      kind: ref.kind === "scriptTrigger" ? "layout" : "script",
+      kind: (ref.kind === "scriptTrigger" || ref.kind === "brokenFieldPlacement") ? "layout" : "script",
       projectId: ref.project_id,
       id: ref.source_id,
       name: ref.source_name,

--- a/src/components/detail/UpgradeCheckPanel.tsx
+++ b/src/components/detail/UpgradeCheckPanel.tsx
@@ -3,8 +3,8 @@ import { useMemo, useState } from "react";
 import { save } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "../../stores/appStore";
-import { useUpgradeCheck } from "../../hooks/analysis";
-import type { UpgradeHit } from "../../types/ddr";
+import { useSolutionBrokenRefs, useUpgradeCheck } from "../../hooks/analysis";
+import type { BrokenRefWithProject, UpgradeHit } from "../../types/ddr";
 import { CARD, SECTION_HEADER } from "../../styles/tokens";
 import { Spinner } from "../Spinner";
 
@@ -48,10 +48,19 @@ async function exportCsv(hits: UpgradeHit[]) {
   await invoke("write_text_file", { path, content: csv });
 }
 
+const BROKEN_REF_KIND_LABEL: Record<BrokenRefWithProject["kind"], string> = {
+  performScript: "Perform Script",
+  scriptTrigger: "スクリプトトリガー",
+  brokenFieldRef: "フィールド参照",
+  brokenLayoutRef: "レイアウト参照",
+};
+
 export function UpgradeCheckPanel({ solutionId }: Props) {
-  const { checkItems, selectElement, setRightPanel } = useAppStore();
+  const { checkItems, showBrokenRefsInUpgradeCheck, selectElement, setRightPanel } = useAppStore();
   const { data: hits = [], isLoading } = useUpgradeCheck(solutionId, checkItems);
+  const { data: brokenRefs = [] } = useSolutionBrokenRefs(solutionId);
   const [openGroups, setOpenGroups] = useState<Set<string>>(new Set());
+  const [brokenRefsOpen, setBrokenRefsOpen] = useState(false);
 
   function toggleGroup(itemId: string) {
     setOpenGroups((prev) => {
@@ -135,6 +144,41 @@ export function UpgradeCheckPanel({ solutionId }: Props) {
           CSV エクスポート
         </button>
       </div>
+
+      {/* 壊れた参照セクション */}
+      {showBrokenRefsInUpgradeCheck && (
+        <div className={CARD}>
+          <button
+            className="w-full flex items-center justify-between text-left"
+            onClick={() => setBrokenRefsOpen((v) => !v)}
+          >
+            <span className={SECTION_HEADER}>壊れた参照</span>
+            <span className="flex items-center gap-2">
+              <span className="text-xs text-gray-400">{brokenRefs.length} 件</span>
+              <span className="text-gray-400 text-xs">{brokenRefsOpen ? "▲" : "▼"}</span>
+            </span>
+          </button>
+          {brokenRefsOpen && (
+            <div className="mt-3 divide-y divide-gray-100">
+              {brokenRefs.length === 0 ? (
+                <p className="text-sm text-gray-400 text-center py-2">壊れた参照なし</p>
+              ) : (
+                brokenRefs.map((ref, i) => (
+                  <div key={i} className="py-2 flex flex-col gap-0.5">
+                    <span className="text-xs text-gray-400">{ref.project_name}</span>
+                    <span className="text-xs text-indigo-500">{BROKEN_REF_KIND_LABEL[ref.kind]}</span>
+                    <span className="text-sm text-gray-700">
+                      {ref.source_name}
+                      <span className="text-gray-400 mx-1">→</span>
+                      <span className="text-red-600">{ref.target_script_name}</span>
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       {groups.length === 0 ? (
         <div className={CARD}>

--- a/src/components/detail/UpgradeCheckPanel.tsx
+++ b/src/components/detail/UpgradeCheckPanel.tsx
@@ -58,7 +58,9 @@ const BROKEN_REF_KIND_LABEL: Record<BrokenRefWithProject["kind"], string> = {
 export function UpgradeCheckPanel({ solutionId }: Props) {
   const { checkItems, showBrokenRefsInUpgradeCheck, selectElement, setRightPanel } = useAppStore();
   const { data: hits = [], isLoading } = useUpgradeCheck(solutionId, checkItems);
-  const { data: brokenRefs = [] } = useSolutionBrokenRefs(solutionId);
+  const { data: brokenRefs = [], isLoading: brokenRefsLoading } = useSolutionBrokenRefs(
+    showBrokenRefsInUpgradeCheck ? solutionId : null
+  );
   const [openGroups, setOpenGroups] = useState<Set<string>>(new Set());
   const [brokenRefsOpen, setBrokenRefsOpen] = useState(false);
 
@@ -154,17 +156,21 @@ export function UpgradeCheckPanel({ solutionId }: Props) {
           >
             <span className={SECTION_HEADER}>壊れた参照</span>
             <span className="flex items-center gap-2">
-              <span className="text-xs text-gray-400">{brokenRefs.length} 件</span>
+              <span className="text-xs text-gray-400">
+                {brokenRefsLoading ? "…" : `${brokenRefs.length} 件`}
+              </span>
               <span className="text-gray-400 text-xs">{brokenRefsOpen ? "▲" : "▼"}</span>
             </span>
           </button>
           {brokenRefsOpen && (
             <div className="mt-3 divide-y divide-gray-100">
-              {brokenRefs.length === 0 ? (
+              {brokenRefsLoading ? (
+                <div className="flex justify-center py-4"><Spinner className="w-4 h-4" /></div>
+              ) : brokenRefs.length === 0 ? (
                 <p className="text-sm text-gray-400 text-center py-2">壊れた参照なし</p>
               ) : (
-                brokenRefs.map((ref, i) => (
-                  <div key={i} className="py-2 flex flex-col gap-0.5">
+                brokenRefs.map((ref) => (
+                  <div key={`${ref.project_id}-${ref.kind}-${ref.source_name}-${ref.target_script_name}`} className="py-2 flex flex-col gap-0.5">
                     <span className="text-xs text-gray-400">{ref.project_name}</span>
                     <span className="text-xs text-indigo-500">{BROKEN_REF_KIND_LABEL[ref.kind]}</span>
                     <span className="text-sm text-gray-700">

--- a/src/components/detail/UpgradeCheckPanel.tsx
+++ b/src/components/detail/UpgradeCheckPanel.tsx
@@ -53,6 +53,7 @@ const BROKEN_REF_KIND_LABEL: Record<BrokenRefWithProject["kind"], string> = {
   scriptTrigger: "スクリプトトリガー",
   brokenFieldRef: "フィールド参照",
   brokenLayoutRef: "レイアウト参照",
+  unknownRef: "参照先不明",
 };
 
 export function UpgradeCheckPanel({ solutionId }: Props) {

--- a/src/components/detail/UpgradeCheckPanel.tsx
+++ b/src/components/detail/UpgradeCheckPanel.tsx
@@ -110,6 +110,16 @@ export function UpgradeCheckPanel({ solutionId }: Props) {
     }
   }
 
+  function handleBrokenRefClick(ref: BrokenRefWithProject) {
+    if (ref.source_id == null) return;
+    selectElement({
+      kind: ref.kind === "scriptTrigger" ? "layout" : "script",
+      projectId: ref.project_id,
+      id: ref.source_id,
+      name: ref.source_name,
+    });
+  }
+
   function handleFieldClick(hit: UpgradeHit) {
     if (hit.field_id != null && hit.table_id != null && hit.table_name != null) {
       selectElement({ kind: "table", projectId: hit.project_id, id: hit.table_id, name: hit.table_name });
@@ -171,7 +181,13 @@ export function UpgradeCheckPanel({ solutionId }: Props) {
                 <p className="text-sm text-gray-400 text-center py-2">壊れた参照なし</p>
               ) : (
                 brokenRefs.map((ref) => (
-                  <div key={`${ref.project_id}-${ref.kind}-${ref.source_name}-${ref.target_script_name}`} className="py-2 flex flex-col gap-0.5">
+                  <button
+                    key={`${ref.project_id}-${ref.kind}-${ref.source_name}-${ref.target_script_name}`}
+                    className="w-full text-left py-2 flex flex-col gap-0.5 hover:bg-gray-50 rounded transition-colors disabled:cursor-default"
+                    onClick={() => handleBrokenRefClick(ref)}
+                    disabled={ref.source_id == null}
+                    title={ref.source_id != null ? `${ref.source_name} を表示` : undefined}
+                  >
                     <span className="text-xs text-gray-400">{ref.project_name}</span>
                     <span className="text-xs text-indigo-500">{BROKEN_REF_KIND_LABEL[ref.kind]}</span>
                     <span className="text-sm text-gray-700">
@@ -179,7 +195,7 @@ export function UpgradeCheckPanel({ solutionId }: Props) {
                       <span className="text-gray-400 mx-1">→</span>
                       <span className="text-red-600">{ref.target_script_name}</span>
                     </span>
-                  </div>
+                  </button>
                 ))
               )}
             </div>

--- a/src/components/detail/UpgradeSettingsPanel.tsx
+++ b/src/components/detail/UpgradeSettingsPanel.tsx
@@ -27,7 +27,7 @@ const EMPTY_CUSTOM: Omit<CheckItem, "id" | "builtin"> = {
 };
 
 export function UpgradeSettingsPanel({ onClose }: { onClose: () => void }) {
-  const { checkItems, setCheckItems } = useAppStore();
+  const { checkItems, setCheckItems, showBrokenRefsInUpgradeCheck, setShowBrokenRefsInUpgradeCheck } = useAppStore();
   const [showAddForm, setShowAddForm] = useState(false);
   const [newItem, setNewItem] = useState<Omit<CheckItem, "id" | "builtin">>(EMPTY_CUSTOM);
 
@@ -100,6 +100,23 @@ export function UpgradeSettingsPanel({ onClose }: { onClose: () => void }) {
               </span>
             </div>
           ))}
+        </div>
+      </div>
+
+      {/* 解析セクション */}
+      <div className={`${CARD} mb-4`}>
+        <p className={`${SECTION_HEADER} mb-3`}>解析</p>
+        <div className="py-2 flex items-center gap-3">
+          <input
+            type="checkbox"
+            id="broken-refs-toggle"
+            checked={showBrokenRefsInUpgradeCheck}
+            onChange={(e) => setShowBrokenRefsInUpgradeCheck(e.target.checked)}
+            className="shrink-0"
+          />
+          <label htmlFor="broken-refs-toggle" className="flex-1 text-sm text-gray-700 cursor-pointer">
+            壊れた参照（Perform Script / スクリプトトリガー等）
+          </label>
         </div>
       </div>
 

--- a/src/hooks/analysis.ts
+++ b/src/hooks/analysis.ts
@@ -2,6 +2,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { useQuery } from "@tanstack/react-query";
 import type {
   BrokenRef,
+  BrokenRefWithProject,
+  ProjectRow,
   ReportCard,
   OrphanScript,
   UnusedFieldRow,
@@ -42,6 +44,24 @@ export function useUnusedFields(projectId: number | null) {
     queryKey: ["unused_fields", projectId],
     queryFn: () => invoke<UnusedFieldRow[]>("list_unused_fields", { projectId }),
     enabled: projectId !== null,
+  });
+}
+
+// ソリューション全体の壊れた参照（全プロジェクトをまとめて取得）
+export function useSolutionBrokenRefs(solutionId: number | null) {
+  return useQuery({
+    queryKey: ["solution_broken_refs", solutionId],
+    queryFn: async (): Promise<BrokenRefWithProject[]> => {
+      const projects = await invoke<ProjectRow[]>("get_solution_projects", { solutionId });
+      const allRefs = await Promise.all(
+        projects.map(async (p) => {
+          const refs = await invoke<BrokenRef[]>("get_broken_refs", { projectId: p.id });
+          return refs.map((r) => ({ ...r, project_id: p.id, project_name: p.name }));
+        })
+      );
+      return allRefs.flat();
+    },
+    enabled: solutionId !== null,
   });
 }
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -17,6 +17,7 @@ export interface CheckItem {
 }
 
 const CHECK_ITEMS_KEY = "fm-ddr-check-items";
+const BROKEN_REFS_KEY = "fm-ddr-show-broken-refs";
 
 const BUILTIN_CHECK_ITEMS: CheckItem[] = [
   { id: "print",              label: "印刷",                       category: "step",            detectionType: "step_type_id",      detectionValue: "43",                enabled: true,  builtin: true },
@@ -33,6 +34,14 @@ const BUILTIN_CHECK_ITEMS: CheckItem[] = [
   { id: "container",          label: "コンテナフィールド",          category: "field",           detectionType: "field_attr",        detectionValue: "container",         enabled: false, builtin: true },
   { id: "custom_function_call", label: "カスタム関数呼び出し",      category: "custom_function", detectionType: "any_custom_function", detectionValue: "",                enabled: true,  builtin: true },
 ];
+
+function loadShowBrokenRefs(): boolean {
+  try {
+    const stored = localStorage.getItem(BROKEN_REFS_KEY);
+    if (stored !== null) return stored === "true";
+  } catch {}
+  return true;
+}
 
 function loadCheckItems(): CheckItem[] {
   try {
@@ -166,7 +175,9 @@ interface AppState {
   searchContains: boolean;
   searchScope: "all" | "solution" | "project";
   checkItems: CheckItem[];
+  showBrokenRefsInUpgradeCheck: boolean;
   setCheckItems: (items: CheckItem[]) => void;
+  setShowBrokenRefsInUpgradeCheck: (v: boolean) => void;
   setSolutions: (solutions: SolutionRow[]) => void;
   setSearchDuration: (duration: number | null) => void;
   setSearchContains: (v: boolean) => void;
@@ -206,9 +217,14 @@ export const useAppStore = create<AppState>((set) => ({
   searchContains: false,
   searchScope: "all",
   checkItems: loadCheckItems(),
+  showBrokenRefsInUpgradeCheck: loadShowBrokenRefs(),
   setCheckItems: (items) => {
     try { localStorage.setItem(CHECK_ITEMS_KEY, JSON.stringify(items)); } catch {}
     set({ checkItems: items });
+  },
+  setShowBrokenRefsInUpgradeCheck: (v) => {
+    try { localStorage.setItem(BROKEN_REFS_KEY, String(v)); } catch {}
+    set({ showBrokenRefsInUpgradeCheck: v });
   },
   setSolutions: (solutions) => set({ solutions }),
   setSearchDuration: (duration) => set({ searchDuration: duration }),

--- a/src/types/ddr.ts
+++ b/src/types/ddr.ts
@@ -52,7 +52,7 @@ export interface SearchResult {
 }
 
 export interface BrokenRef {
-  kind: "performScript" | "scriptTrigger" | "brokenFieldRef" | "brokenLayoutRef" | "unknownRef";
+  kind: "performScript" | "scriptTrigger" | "brokenFieldRef" | "brokenLayoutRef" | "unknownRef" | "brokenFieldPlacement";
   source_name: string;
   target_script_name: string;
   source_id?: number;

--- a/src/types/ddr.ts
+++ b/src/types/ddr.ts
@@ -52,7 +52,7 @@ export interface SearchResult {
 }
 
 export interface BrokenRef {
-  kind: "performScript" | "scriptTrigger" | "brokenFieldRef" | "brokenLayoutRef";
+  kind: "performScript" | "scriptTrigger" | "brokenFieldRef" | "brokenLayoutRef" | "unknownRef";
   source_name: string;
   target_script_name: string;
 }

--- a/src/types/ddr.ts
+++ b/src/types/ddr.ts
@@ -55,6 +55,7 @@ export interface BrokenRef {
   kind: "performScript" | "scriptTrigger" | "brokenFieldRef" | "brokenLayoutRef" | "unknownRef";
   source_name: string;
   target_script_name: string;
+  source_id?: number;
 }
 
 export interface BrokenRefWithProject extends BrokenRef {

--- a/src/types/ddr.ts
+++ b/src/types/ddr.ts
@@ -57,6 +57,11 @@ export interface BrokenRef {
   target_script_name: string;
 }
 
+export interface BrokenRefWithProject extends BrokenRef {
+  project_id: number;
+  project_name: string;
+}
+
 export type Severity = "Info" | "Warning" | "Error";
 
 export interface ReportIssue {


### PR DESCRIPTION
## Summary

- `UpgradeCheckPanel` に壊れた参照アコーディオンセクションを追加（ソリューション全プロジェクトを集約して表示）
- `UpgradeSettingsPanel` に「解析」セクションのトグルを追加（`showBrokenRefsInUpgradeCheck` フラグで IPC 制御）
- `BrokenRefKind::UnknownRef` を追加し、`step_text` に `<不明>` を含むステップ（ファイルを開く・Perform Script 外部参照等）を参照切れとして検出
- `BrokenRefWithProject` 型と `useSolutionBrokenRefs` hook を追加（`Promise.all` で全プロジェクト集約）

## Test plan

- [ ] `npm run test` — 344 passed
- [ ] `cargo test --lib` — 395 passed（`UnknownRef` 検出テスト3件含む）
- [ ] `cargo fmt` / `cargo clippy` / `tsc --noEmit` すべて通過
- [ ] UpgradeCheckPanel に壊れた参照セクションが表示されること
- [ ] 設定パネルでトグルを OFF にすると IPC が発行されないこと
- [ ] `ファイルを開く [ <不明> ]` のようなステップが `参照先不明` として一覧に表示されること

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)