### PR TITLE
fix: スティッキーヘッダー + カラム幅リサイズを全一覧パネルと詳細パネルに実装

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -99,12 +99,12 @@ filemaker-ddr-viewer/
 | `StatusBar.tsx` | 下部ステータスバー |
 | `Spinner.tsx` | ローディングスピナー |
 | `ErrorBoundary.tsx` | React エラーバウンダリ |
-| `detail/TableDetail.tsx` | テーブル詳細・フィールド一覧 |
+| `detail/TableDetail.tsx` | テーブル詳細・フィールド一覧。タイトルを `shrink-0` ヘッダーに固定し、フィールドテーブルは `flex-1 overflow-auto` 内でスクロール。`useColumnResize` でカラム幅ドラッグ変更可能 |
 | `detail/FieldDetail.tsx` | フィールド詳細・Where Used |
 | `detail/ScriptDetail.tsx` | スクリプト詳細・ステップ一覧・diff表示 |
-| `detail/LayoutDetail.tsx` | レイアウト詳細・トリガー・オブジェクト |
+| `detail/LayoutDetail.tsx` | レイアウト詳細・トリガー・オブジェクト。タイトル・テーブルオカレンス・トリガーテーブルを `shrink-0` ヘッダーに固定し、オブジェクト一覧は `flex-1 overflow-auto` 内でスクロール。`useColumnResize` でカラム幅ドラッグ変更可能 |
 | `detail/LayoutObjectDetail.tsx` | レイアウトオブジェクト詳細 |
-| `detail/All*Panel.tsx` | 各エンティティの横断一覧（AllTablesPanel / AllFieldsPanel / AllScriptsPanel / AllLayoutsPanel / AllTableOccurrencesPanel / AllRelationshipsPanel / AllValueListsPanel / AllCustomFunctionsPanel / AllExternalDataSourcesPanel）。AllFieldsPanel は `@tanstack/react-virtual` の `useVirtualizer` で仮想スクロール化済み |
+| `detail/All*Panel.tsx` | 各エンティティの横断一覧（AllTablesPanel / AllFieldsPanel / AllScriptsPanel / AllLayoutsPanel / AllTableOccurrencesPanel / AllRelationshipsPanel / AllValueListsPanel / AllCustomFunctionsPanel / AllExternalDataSourcesPanel）。全パネル共通でタイトル・フィルター・ページネーションを `shrink-0` ヘッダーに固定し、テーブルは `flex-1 overflow-auto` 内でスクロール。`useColumnResize` でカラム幅ドラッグ変更可能。AllFieldsPanel は `@tanstack/react-virtual` の `useVirtualizer` で仮想スクロール化済み |
 | `detail/RelationshipGraphPanel.tsx` | リレーショングラフ（dagre + SVG、pan/zoom 対応） |
 | `detail/CallChainTree.tsx` | コールチェーンツリー |
 | `detail/WhereUsed.tsx` | 参照元一覧 |
@@ -114,6 +114,7 @@ filemaker-ddr-viewer/
 | `DiffView.tsx` | 差分比較ビュー |
 | `stores/appStore.ts` | グローバル状態（zustand） |
 | `hooks/` | ドメイン別 Tauri IPC フック（analysis / catalog / diff / fieldRefs / layout / script / search / security / solutions / table）。`hooks/analysis.ts` の `useSolutionBrokenRefs` はソリューション全プロジェクトの壊れた参照を `Promise.all` で集約 |
+| `hooks/useColumnResize.ts` | テーブルのカラム幅ドラッグリサイズフック。`table-layout:fixed` + `<colgroup>` と組み合わせて使用。ドラッグ開始時に全列幅を DOM から実測して固定し、N 列を広げると N+1 列が縮む（合計幅一定）。最終列のみ単独変更 |
 | `hooks/useSearchFiltering.ts` | 検索フィルタリングロジック |
 | `styles/tokens.ts` | デザイントークン定数 |
 

--- a/src/__tests__/hooks/useColumnResize.test.ts
+++ b/src/__tests__/hooks/useColumnResize.test.ts
@@ -1,0 +1,139 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { useColumnResize } from "../../hooks/useColumnResize";
+
+describe("useColumnResize", () => {
+  it("初期状態で widths がすべて undefined", () => {
+    const { result } = renderHook(() => useColumnResize(3));
+    expect(result.current.widths).toEqual([undefined, undefined, undefined]);
+  });
+
+  it("setThRef が th 要素を ref に登録する", () => {
+    const { result } = renderHook(() => useColumnResize(2));
+    const el = document.createElement("th");
+    Object.defineProperty(el, "offsetWidth", { value: 120, configurable: true });
+
+    act(() => {
+      result.current.setThRef(0)(el);
+    });
+
+    // ref 登録後に onMouseDown を呼ぶと frozenWidths に反映される
+    const el2 = document.createElement("th");
+    Object.defineProperty(el2, "offsetWidth", { value: 80, configurable: true });
+    act(() => {
+      result.current.setThRef(1)(el2);
+    });
+
+    act(() => {
+      result.current.getResizeHandleProps(0).onMouseDown({
+        preventDefault: () => {},
+        stopPropagation: () => {},
+        clientX: 0,
+      } as unknown as React.MouseEvent);
+    });
+
+    // onMouseDown だけでは widths が frozenWidths に初期化される
+    expect(result.current.widths).toEqual([120, 80]);
+  });
+
+  it("mousemove で対象列が広がり隣接列が縮む", () => {
+    const { result } = renderHook(() => useColumnResize(2));
+
+    const th0 = document.createElement("th");
+    Object.defineProperty(th0, "offsetWidth", { value: 100, configurable: true });
+    const th1 = document.createElement("th");
+    Object.defineProperty(th1, "offsetWidth", { value: 200, configurable: true });
+
+    act(() => {
+      result.current.setThRef(0)(th0);
+      result.current.setThRef(1)(th1);
+    });
+
+    act(() => {
+      result.current.getResizeHandleProps(0).onMouseDown({
+        preventDefault: () => {},
+        stopPropagation: () => {},
+        clientX: 50,
+      } as unknown as React.MouseEvent);
+    });
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 70 }));
+    });
+
+    // +20px ドラッグ: col0 → 120, col1 → 180
+    expect(result.current.widths[0]).toBe(120);
+    expect(result.current.widths[1]).toBe(180);
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    });
+  });
+
+  it("最小幅 40px を下回らない", () => {
+    const { result } = renderHook(() => useColumnResize(2));
+
+    const th0 = document.createElement("th");
+    Object.defineProperty(th0, "offsetWidth", { value: 50, configurable: true });
+    const th1 = document.createElement("th");
+    Object.defineProperty(th1, "offsetWidth", { value: 50, configurable: true });
+
+    act(() => {
+      result.current.setThRef(0)(th0);
+      result.current.setThRef(1)(th1);
+    });
+
+    act(() => {
+      result.current.getResizeHandleProps(0).onMouseDown({
+        preventDefault: () => {},
+        stopPropagation: () => {},
+        clientX: 50,
+      } as unknown as React.MouseEvent);
+    });
+
+    // -100px ドラッグ → 最小幅 40 にクランプされる
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: -50 }));
+    });
+
+    expect(result.current.widths[0]).toBe(40);
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    });
+  });
+
+  it("最終列のみリサイズ時は隣接列が変化しない", () => {
+    const { result } = renderHook(() => useColumnResize(2));
+
+    const th0 = document.createElement("th");
+    Object.defineProperty(th0, "offsetWidth", { value: 100, configurable: true });
+    const th1 = document.createElement("th");
+    Object.defineProperty(th1, "offsetWidth", { value: 100, configurable: true });
+
+    act(() => {
+      result.current.setThRef(0)(th0);
+      result.current.setThRef(1)(th1);
+    });
+
+    act(() => {
+      result.current.getResizeHandleProps(1).onMouseDown({
+        preventDefault: () => {},
+        stopPropagation: () => {},
+        clientX: 50,
+      } as unknown as React.MouseEvent);
+    });
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 80 }));
+    });
+
+    // 最終列(idx=1)のみ変化。col0 は frozenWidths のまま
+    expect(result.current.widths[0]).toBe(100);
+    expect(result.current.widths[1]).toBe(130);
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    });
+  });
+});

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -150,7 +150,7 @@ export function MainContent() {
         );
       case "all_table_occurrences":
         return (
-          <div className="flex-1 overflow-hidden flex flex-col">
+          <div className="flex-1 overflow-hidden flex flex-col" data-testid="detail-panel">
             <AllTableOccurrencesPanel projectId={selectedElement.projectId} />
           </div>
         );
@@ -162,7 +162,7 @@ export function MainContent() {
         );
       case "all_relationships":
         return (
-          <div className="flex-1 overflow-hidden flex flex-col">
+          <div className="flex-1 overflow-hidden flex flex-col" data-testid="detail-panel">
             <AllRelationshipsPanel projectId={selectedElement.projectId} highlightId={selectedElement.highlightId} />
           </div>
         );

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -62,7 +62,7 @@ export function MainContent() {
         );
       case "table":
         return (
-          <div className="flex-1 overflow-auto" data-testid="detail-panel">
+          <div className="flex-1 overflow-hidden flex flex-col" data-testid="detail-panel">
             <TableDetail
               projectId={selectedElement.projectId}
               tableId={selectedElement.id}
@@ -87,7 +87,7 @@ export function MainContent() {
         const layout = layouts.find((l) => l.id === selectedElement.id);
         if (layout) {
           return (
-            <div className="flex-1 overflow-auto" data-testid="detail-panel">
+            <div className="flex-1 overflow-hidden flex flex-col" data-testid="detail-panel">
               <LayoutDetail layout={layout} projectId={selectedElement.projectId} />
             </div>
           );

--- a/src/components/detail/AllCustomFunctionsPanel.tsx
+++ b/src/components/detail/AllCustomFunctionsPanel.tsx
@@ -3,6 +3,7 @@ import { useCustomFunctionList } from "../../hooks/catalog";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
+import { useColumnResize } from "../../hooks/useColumnResize";
 
 
 interface Props {
@@ -15,6 +16,7 @@ export function AllCustomFunctionsPanel({ projectId }: Props) {
 
   const { data: customFunctions = [], isLoading } = useCustomFunctionList(projectId, PAGE_SIZE, page * PAGE_SIZE);
   const { selectElement } = useAppStore();
+  const { widths, setThRef, getResizeHandleProps } = useColumnResize(2);
 
   const isLastPage = customFunctions.length < PAGE_SIZE;
 
@@ -74,12 +76,15 @@ export function AllCustomFunctionsPanel({ projectId }: Props) {
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto px-4 pb-4">
-        <table className="w-full text-sm border-collapse">
+      <div className="flex-1 overflow-auto [scrollbar-gutter:stable] px-4 pb-4">
+        <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
+          <colgroup>
+            {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+          </colgroup>
           <thead className="sticky top-0 bg-white z-10">
             <tr className="bg-gray-100 text-left">
-              <th className="px-3 py-2 border border-gray-200">カスタム関数名</th>
-              <th className="px-3 py-2 border border-gray-200">パラメータ</th>
+              <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 relative">カスタム関数名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
+              <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 relative">パラメータ<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/detail/AllExternalDataSourcesPanel.tsx
+++ b/src/components/detail/AllExternalDataSourcesPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import { useExternalDataSourceList } from "../../hooks/catalog";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
+import { useColumnResize } from "../../hooks/useColumnResize";
 
 interface Props {
   projectId: number;
@@ -18,6 +19,7 @@ export function AllExternalDataSourcesPanel({ projectId }: Props) {
   );
 
   const isLastPage = sources.length < PAGE_SIZE;
+  const { widths, setThRef, getResizeHandleProps } = useColumnResize(3);
 
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase();
@@ -80,17 +82,16 @@ export function AllExternalDataSourcesPanel({ projectId }: Props) {
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto px-4 pb-4">
-        <table className="w-full text-sm border-collapse">
+      <div className="flex-1 overflow-auto [scrollbar-gutter:stable] px-4 pb-4">
+        <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
+          <colgroup>
+            {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+          </colgroup>
           <thead className="sticky top-0 bg-white z-10">
             <tr className="bg-gray-100 text-left">
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">
-                ファイル名
-              </th>
-              <th className="px-3 py-2 border border-gray-200">パス</th>
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">
-                DDR リンク
-              </th>
+              <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">ファイル名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
+              <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 relative">パス<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
+              <th ref={setThRef(2)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">DDR リンク<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(2)} /></th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/detail/AllFieldsPanel.tsx
+++ b/src/components/detail/AllFieldsPanel.tsx
@@ -4,6 +4,7 @@ import { useAllFields } from "../../hooks/table";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
+import { useColumnResize } from "../../hooks/useColumnResize";
 
 
 interface Props {
@@ -36,6 +37,7 @@ export function AllFieldsPanel({ projectId }: Props) {
   }, [fields, filter]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
+  const { widths, setThRef, getResizeHandleProps } = useColumnResize(6);
 
   const virtualizer = useVirtualizer({
     count: filtered.length,
@@ -103,16 +105,19 @@ export function AllFieldsPanel({ projectId }: Props) {
       </div>
 
       {/* テーブル */}
-      <div ref={scrollRef} className="flex-1 overflow-auto px-4 pb-4">
-        <table className="w-full text-sm border-collapse">
+      <div ref={scrollRef} className="flex-1 overflow-auto [scrollbar-gutter:stable] px-4 pb-4">
+        <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
+          <colgroup>
+            {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+          </colgroup>
           <thead className="sticky top-0 bg-white z-10">
             <tr className="bg-gray-100 text-left">
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">テーブル</th>
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">フィールド名</th>
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">型</th>
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">種別</th>
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">G</th>
-              <th className="px-3 py-2 border border-gray-200">コメント</th>
+              <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">テーブル<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
+              <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">フィールド名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
+              <th ref={setThRef(2)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">型<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(2)} /></th>
+              <th ref={setThRef(3)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">種別<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(3)} /></th>
+              <th ref={setThRef(4)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">G<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(4)} /></th>
+              <th ref={setThRef(5)} className="px-3 py-2 border border-gray-200 relative">コメント<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(5)} /></th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/detail/AllLayoutsPanel.tsx
+++ b/src/components/detail/AllLayoutsPanel.tsx
@@ -3,6 +3,7 @@ import { useLayoutList } from "../../hooks/layout";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
+import { useColumnResize } from "../../hooks/useColumnResize";
 
 
 interface Props {
@@ -15,6 +16,7 @@ export function AllLayoutsPanel({ projectId }: Props) {
 
   const { data: layouts = [], isLoading } = useLayoutList(projectId, PAGE_SIZE, page * PAGE_SIZE);
   const { selectElement } = useAppStore();
+  const { widths, setThRef, getResizeHandleProps } = useColumnResize(3);
 
   const isLastPage = layouts.length < PAGE_SIZE;
 
@@ -74,13 +76,16 @@ export function AllLayoutsPanel({ projectId }: Props) {
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto px-4 pb-4">
-        <table className="w-full text-sm border-collapse">
+      <div className="flex-1 overflow-auto [scrollbar-gutter:stable] px-4 pb-4">
+        <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
+          <colgroup>
+            {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+          </colgroup>
           <thead className="sticky top-0 bg-white z-10">
             <tr className="bg-gray-100 text-left">
-              <th className="px-3 py-2 border border-gray-200">レイアウト名</th>
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">テーブルオカレンス</th>
-              <th className="px-3 py-2 border border-gray-200 text-right whitespace-nowrap">トリガー数</th>
+              <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 relative">レイアウト名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
+              <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">テーブルオカレンス<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
+              <th ref={setThRef(2)} className="px-3 py-2 border border-gray-200 text-right whitespace-nowrap relative">トリガー数<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(2)} /></th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/detail/AllRelationshipsPanel.tsx
+++ b/src/components/detail/AllRelationshipsPanel.tsx
@@ -3,6 +3,7 @@ import { useRelationshipList } from "../../hooks/table";
 import type { RelationshipRow } from "../../types/ddr";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
+import { useColumnResize } from "../../hooks/useColumnResize";
 
 interface Props {
   projectId: number;
@@ -20,6 +21,7 @@ export function AllRelationshipsPanel({ projectId, highlightId }: Props) {
   const [filter, setFilter] = useState("");
   const { data: relationships = [], isLoading } = useRelationshipList(projectId, PAGE_SIZE, page * PAGE_SIZE);
   const highlightRef = useRef<HTMLTableRowElement>(null);
+  const { widths, setThRef, getResizeHandleProps } = useColumnResize(3);
   const isLastPage = relationships.length < PAGE_SIZE;
 
   useEffect(() => {
@@ -91,13 +93,16 @@ export function AllRelationshipsPanel({ projectId, highlightId }: Props) {
       </div>
 
       {/* テーブル */}
-      <div className="flex-1 overflow-auto px-4 pb-4">
-        <table className="w-full text-sm border-collapse">
+      <div className="flex-1 overflow-auto [scrollbar-gutter:stable] px-4 pb-4">
+        <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
+          <colgroup>
+            {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+          </colgroup>
           <thead className="sticky top-0 bg-white z-10">
             <tr className="bg-gray-100 text-left">
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">左テーブル</th>
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">右テーブル</th>
-              <th className="px-3 py-2 border border-gray-200">結合条件</th>
+              <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">左テーブル<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
+              <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">右テーブル<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
+              <th ref={setThRef(2)} className="px-3 py-2 border border-gray-200 relative">結合条件<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(2)} /></th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/detail/AllScriptsPanel.tsx
+++ b/src/components/detail/AllScriptsPanel.tsx
@@ -3,6 +3,7 @@ import { useScriptList } from "../../hooks/script";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
+import { useColumnResize } from "../../hooks/useColumnResize";
 
 
 interface Props {
@@ -15,6 +16,7 @@ export function AllScriptsPanel({ projectId }: Props) {
 
   const { data: scripts = [], isLoading } = useScriptList(projectId, PAGE_SIZE, page * PAGE_SIZE);
   const { selectElement } = useAppStore();
+  const { widths, setThRef, getResizeHandleProps } = useColumnResize(2);
 
   const isLastPage = scripts.length < PAGE_SIZE;
 
@@ -70,12 +72,15 @@ export function AllScriptsPanel({ projectId }: Props) {
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto px-4 pb-4">
-        <table className="w-full text-sm border-collapse">
+      <div className="flex-1 overflow-auto [scrollbar-gutter:stable] px-4 pb-4">
+        <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
+          <colgroup>
+            {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+          </colgroup>
           <thead className="sticky top-0 bg-white z-10">
             <tr className="bg-gray-100 text-left">
-              <th className="px-3 py-2 border border-gray-200">スクリプト名</th>
-              <th className="px-3 py-2 border border-gray-200 text-right whitespace-nowrap">ステップ数</th>
+              <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 relative">スクリプト名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
+              <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 text-right whitespace-nowrap relative">ステップ数<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/detail/AllTableOccurrencesPanel.tsx
+++ b/src/components/detail/AllTableOccurrencesPanel.tsx
@@ -6,6 +6,7 @@ import { useLayoutList } from "../../hooks/layout";
 import { useAppStore } from "../../stores/appStore";
 import type { LayoutRow } from "../../types/ddr";
 import { PAGE_SIZE } from "../../constants";
+import { useColumnResize } from "../../hooks/useColumnResize";
 
 
 interface Props {
@@ -20,6 +21,7 @@ export function AllTableOccurrencesPanel({ projectId }: Props) {
   const { data: tables = [] } = useTableList(projectId);
   const { data: layouts = [] } = useLayoutList(projectId);
   const { selectElement, setRightPanel } = useAppStore();
+  const { widths, setThRef, getResizeHandleProps } = useColumnResize(4);
 
   const isLastPage = tableOccurrences.length < PAGE_SIZE;
 
@@ -99,14 +101,17 @@ export function AllTableOccurrencesPanel({ projectId }: Props) {
       </div>
 
       {/* テーブル */}
-      <div className="flex-1 overflow-auto px-4 pb-4">
-        <table className="w-full text-sm border-collapse">
+      <div className="flex-1 overflow-auto [scrollbar-gutter:stable] px-4 pb-4">
+        <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
+          <colgroup>
+            {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+          </colgroup>
           <thead className="sticky top-0 bg-white z-10">
             <tr className="bg-gray-100 text-left">
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">オカレンス名</th>
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">ベーステーブル</th>
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">外部ファイル</th>
-              <th className="px-3 py-2 border border-gray-200">使用レイアウト</th>
+              <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">オカレンス名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
+              <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">ベーステーブル<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
+              <th ref={setThRef(2)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">外部ファイル<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(2)} /></th>
+              <th ref={setThRef(3)} className="px-3 py-2 border border-gray-200 relative">使用レイアウト<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(3)} /></th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/detail/AllTablesPanel.tsx
+++ b/src/components/detail/AllTablesPanel.tsx
@@ -3,6 +3,7 @@ import { useTableList } from "../../hooks/table";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
+import { useColumnResize } from "../../hooks/useColumnResize";
 
 
 interface Props {
@@ -15,6 +16,7 @@ export function AllTablesPanel({ projectId }: Props) {
 
   const { data: tables = [], isLoading } = useTableList(projectId, PAGE_SIZE, page * PAGE_SIZE);
   const { selectElement } = useAppStore();
+  const { widths, setThRef, getResizeHandleProps } = useColumnResize(2);
 
   const isLastPage = tables.length < PAGE_SIZE;
 
@@ -70,12 +72,15 @@ export function AllTablesPanel({ projectId }: Props) {
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto px-4 pb-4">
-        <table className="w-full text-sm border-collapse">
+      <div className="flex-1 overflow-auto [scrollbar-gutter:stable] px-4 pb-4">
+        <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
+          <colgroup>
+            {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+          </colgroup>
           <thead className="sticky top-0 bg-white z-10">
             <tr className="bg-gray-100 text-left">
-              <th className="px-3 py-2 border border-gray-200">テーブル名</th>
-              <th className="px-3 py-2 border border-gray-200 text-right whitespace-nowrap">フィールド数</th>
+              <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 relative">テーブル名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
+              <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 text-right whitespace-nowrap relative">フィールド数<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/detail/AllValueListsPanel.tsx
+++ b/src/components/detail/AllValueListsPanel.tsx
@@ -3,6 +3,7 @@ import { useValueListList } from "../../hooks/catalog";
 import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
+import { useColumnResize } from "../../hooks/useColumnResize";
 
 
 interface Props {
@@ -15,6 +16,7 @@ export function AllValueListsPanel({ projectId }: Props) {
 
   const { data: valueLists = [], isLoading } = useValueListList(projectId, PAGE_SIZE, page * PAGE_SIZE);
   const { selectElement } = useAppStore();
+  const { widths, setThRef, getResizeHandleProps } = useColumnResize(3);
 
   const isLastPage = valueLists.length < PAGE_SIZE;
 
@@ -74,13 +76,16 @@ export function AllValueListsPanel({ projectId }: Props) {
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto px-4 pb-4">
-        <table className="w-full text-sm border-collapse">
+      <div className="flex-1 overflow-auto [scrollbar-gutter:stable] px-4 pb-4">
+        <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
+          <colgroup>
+            {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+          </colgroup>
           <thead className="sticky top-0 bg-white z-10">
             <tr className="bg-gray-100 text-left">
-              <th className="px-3 py-2 border border-gray-200">バリューリスト名</th>
-              <th className="px-3 py-2 border border-gray-200 whitespace-nowrap">ソース</th>
-              <th className="px-3 py-2 border border-gray-200 text-right whitespace-nowrap">値の件数</th>
+              <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 relative">バリューリスト名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
+              <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 whitespace-nowrap relative">ソース<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
+              <th ref={setThRef(2)} className="px-3 py-2 border border-gray-200 text-right whitespace-nowrap relative">値の件数<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(2)} /></th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/detail/LayoutDetail.tsx
+++ b/src/components/detail/LayoutDetail.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { useLayoutTriggers, useLayoutObjects, useLayoutList } from "../../hooks/layout";
 import { useScriptList } from "../../hooks/script";
 import { useAppStore } from "../../stores/appStore";
+import { useColumnResize } from "../../hooks/useColumnResize";
 import type { LayoutRow, LayoutObjectRow } from "../../types/ddr";
 import { Spinner } from "../Spinner";
 import { SECTION_HEADER } from "../../styles/tokens";
@@ -52,6 +53,7 @@ export function LayoutDetail({ layout, projectId }: Props) {
   const { data: objects = [], isLoading: objectsLoading } = useLayoutObjects(layout.id);
   const { data: scripts = [] } = useScriptList(projectId);
   const { setRightPanel, rightPanel, selectElement, diffContext } = useAppStore();
+  const { widths: objWidths, setThRef: setObjThRef, getResizeHandleProps: getObjResizeHandleProps } = useColumnResize(6);
 
   // diff ハイライト用: 比較元プロジェクトの同名レイアウトのオブジェクトを取得
   const compareProjectId = diffContext?.compareProjectId ?? null;
@@ -104,109 +106,116 @@ export function LayoutDetail({ layout, projectId }: Props) {
   }
 
   return (
-    <div className="p-4">
-      <h2 className="text-lg font-bold mb-4 text-gray-800">{layout.name}</h2>
+    <div className="flex flex-col h-full">
+      <div className="px-4 pt-4 pb-2 shrink-0">
+        <h2 className="text-lg font-bold mb-2 text-gray-800">{layout.name}</h2>
 
-      {/* テーブルオカレンス */}
-      <div className="mb-4">
-        <span className="text-sm font-semibold text-gray-600">テーブルオカレンス: </span>
-        <span className="text-sm text-gray-800">
-          {layout.table_occurrence_name ?? "—"}
-        </span>
+        {/* テーブルオカレンス */}
+        <div className="mb-2">
+          <span className="text-sm font-semibold text-gray-600">テーブルオカレンス: </span>
+          <span className="text-sm text-gray-800">
+            {layout.table_occurrence_name ?? "—"}
+          </span>
+        </div>
+
+        {/* トリガー一覧 */}
+        <h3 className={SECTION_HEADER}>スクリプトトリガー</h3>
+        {triggers.length === 0 ? (
+          <p className="text-gray-500 text-sm mb-2">トリガーなし</p>
+        ) : (
+          <table className="w-full text-sm border-separate border-spacing-0 mb-2">
+            <thead>
+              <tr className="bg-gray-100 text-left">
+                <th className="px-3 py-2 border border-gray-200">イベント</th>
+                <th className="px-3 py-2 border border-gray-200">スクリプト名</th>
+                <th className="px-3 py-2 border border-gray-200">ファイル</th>
+              </tr>
+            </thead>
+            <tbody>
+              {triggers.map((trigger) => {
+                const targetScript = scripts.find((s) => s.name === trigger.script_name);
+                return (
+                  <tr key={trigger.id} className="hover:bg-blue-50">
+                    <td className="px-3 py-2 border border-gray-200 font-mono text-xs">
+                      {trigger.event}
+                    </td>
+                    <td className="px-3 py-2 border border-gray-200">
+                      {targetScript ? (
+                        <button
+                          className="text-blue-600 hover:underline text-left"
+                          onClick={() => {
+                            setRightPanel(null);
+                            selectElement({
+                              kind: "script",
+                              projectId,
+                              id: targetScript.id,
+                              name: targetScript.name,
+                            });
+                          }}
+                        >
+                          {trigger.script_name}
+                        </button>
+                      ) : (
+                        <span className="text-gray-500">{trigger.script_name}</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 border border-gray-200 text-gray-500 text-xs">
+                      {trigger.file_name}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+
+        {/* オブジェクト一覧ヘッダー */}
+        <h3 className={SECTION_HEADER}>
+          オブジェクト一覧
+          <span className="ml-2 text-xs font-normal text-gray-400">
+            クリックで詳細を表示
+          </span>
+        </h3>
+        {compareProjectId && diffMap.size > 0 && (
+          <div className="flex gap-3 text-xs mb-1">
+            {[...new Set(diffMap.values())].includes("Added") && (
+              <span className="inline-flex items-center gap-1 text-green-700">
+                <span className="w-2 h-2 rounded-full bg-green-400 inline-block" />
+                追加
+              </span>
+            )}
+            {[...new Set(diffMap.values())].includes("Removed") && (
+              <span className="inline-flex items-center gap-1 text-red-600">
+                <span className="w-2 h-2 rounded-full bg-red-400 inline-block" />
+                削除
+              </span>
+            )}
+            {[...new Set(diffMap.values())].includes("Modified") && (
+              <span className="inline-flex items-center gap-1 text-yellow-700">
+                <span className="w-2 h-2 rounded-full bg-yellow-400 inline-block" />
+                変更
+              </span>
+            )}
+          </div>
+        )}
       </div>
 
-      {/* トリガー一覧 */}
-      <h3 className={SECTION_HEADER}>スクリプトトリガー</h3>
-      {triggers.length === 0 ? (
-        <p className="text-gray-500 text-sm mb-6">トリガーなし</p>
-      ) : (
-        <table className="w-full text-sm border-collapse mb-6">
-          <thead>
-            <tr className="bg-gray-100 text-left">
-              <th className="px-3 py-2 border border-gray-200">イベント</th>
-              <th className="px-3 py-2 border border-gray-200">スクリプト名</th>
-              <th className="px-3 py-2 border border-gray-200">ファイル</th>
-            </tr>
-          </thead>
-          <tbody>
-            {triggers.map((trigger) => {
-              const targetScript = scripts.find((s) => s.name === trigger.script_name);
-              return (
-                <tr key={trigger.id} className="hover:bg-blue-50">
-                  <td className="px-3 py-2 border border-gray-200 font-mono text-xs">
-                    {trigger.event}
-                  </td>
-                  <td className="px-3 py-2 border border-gray-200">
-                    {targetScript ? (
-                      <button
-                        className="text-blue-600 hover:underline text-left"
-                        onClick={() => {
-                          setRightPanel(null);
-                          selectElement({
-                            kind: "script",
-                            projectId,
-                            id: targetScript.id,
-                            name: targetScript.name,
-                          });
-                        }}
-                      >
-                        {trigger.script_name}
-                      </button>
-                    ) : (
-                      <span className="text-gray-500">{trigger.script_name}</span>
-                    )}
-                  </td>
-                  <td className="px-3 py-2 border border-gray-200 text-gray-500 text-xs">
-                    {trigger.file_name}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      )}
-
-      {/* オブジェクト一覧 */}
-      <h3 className={SECTION_HEADER}>
-        オブジェクト一覧
-        <span className="ml-2 text-xs font-normal text-gray-400">
-          クリックで詳細を表示
-        </span>
-      </h3>
-      {compareProjectId && diffMap.size > 0 && (
-        <div className="flex gap-3 text-xs mb-2">
-          {[...new Set(diffMap.values())].includes("Added") && (
-            <span className="inline-flex items-center gap-1 text-green-700">
-              <span className="w-2 h-2 rounded-full bg-green-400 inline-block" />
-              追加
-            </span>
-          )}
-          {[...new Set(diffMap.values())].includes("Removed") && (
-            <span className="inline-flex items-center gap-1 text-red-600">
-              <span className="w-2 h-2 rounded-full bg-red-400 inline-block" />
-              削除
-            </span>
-          )}
-          {[...new Set(diffMap.values())].includes("Modified") && (
-            <span className="inline-flex items-center gap-1 text-yellow-700">
-              <span className="w-2 h-2 rounded-full bg-yellow-400 inline-block" />
-              変更
-            </span>
-          )}
-        </div>
-      )}
+      <div className="flex-1 overflow-auto [scrollbar-gutter:stable] px-4 pb-4">
       {allObjects.length === 0 ? (
         <p className="text-gray-500 text-sm">オブジェクトなし</p>
       ) : (
-        <table className="w-full text-sm border-collapse">
-          <thead>
+        <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
+          <colgroup>
+            {objWidths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+          </colgroup>
+          <thead className="sticky top-0 bg-white z-10">
             <tr className="bg-gray-100 text-left">
-              <th className="px-3 py-2 border border-gray-200">種別</th>
-              <th className="px-3 py-2 border border-gray-200">オブジェクト名</th>
-              <th className="px-3 py-2 border border-gray-200">ラベル</th>
-              <th className="px-3 py-2 border border-gray-200">フィールド</th>
-              <th className="px-3 py-2 border border-gray-200">ツールチップ</th>
-              <th className="px-3 py-2 border border-gray-200">条件非表示</th>
+              <th ref={setObjThRef(0)} className="px-3 py-2 border border-gray-200 relative">種別<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getObjResizeHandleProps(0)} /></th>
+              <th ref={setObjThRef(1)} className="px-3 py-2 border border-gray-200 relative">オブジェクト名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getObjResizeHandleProps(1)} /></th>
+              <th ref={setObjThRef(2)} className="px-3 py-2 border border-gray-200 relative">ラベル<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getObjResizeHandleProps(2)} /></th>
+              <th ref={setObjThRef(3)} className="px-3 py-2 border border-gray-200 relative">フィールド<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getObjResizeHandleProps(3)} /></th>
+              <th ref={setObjThRef(4)} className="px-3 py-2 border border-gray-200 relative">ツールチップ<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getObjResizeHandleProps(4)} /></th>
+              <th ref={setObjThRef(5)} className="px-3 py-2 border border-gray-200 relative">条件非表示<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getObjResizeHandleProps(5)} /></th>
             </tr>
           </thead>
           <tbody>
@@ -268,6 +277,7 @@ export function LayoutDetail({ layout, projectId }: Props) {
           </tbody>
         </table>
       )}
+      </div>
     </div>
   );
 }

--- a/src/components/detail/TableDetail.tsx
+++ b/src/components/detail/TableDetail.tsx
@@ -127,21 +127,21 @@ export function TableDetail({ projectId, tableId, name }: Props) {
         <p className="text-gray-500">フィールドなし</p>
       ) : (
         <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
-            <colgroup>
-              {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
-            </colgroup>
-            <thead className="sticky top-0 bg-white z-10">
-              <tr className="bg-gray-100 text-left">
-                <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 relative">フィールド名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
-                <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 relative">データ型<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
-                <th ref={setThRef(2)} className="px-3 py-2 border border-gray-200 relative">種別<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(2)} /></th>
-                <th ref={setThRef(3)} className="px-3 py-2 border border-gray-200 relative">グローバル<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(3)} /></th>
-                <th ref={setThRef(4)} className="px-3 py-2 border border-gray-200 relative">繰り返し<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(4)} /></th>
-                <th ref={setThRef(5)} className="px-3 py-2 border border-gray-200 relative">計算式<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(5)} /></th>
-              </tr>
-            </thead>
-            <tbody>
-              {allRows.map((field) => {
+          <colgroup>
+            {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+          </colgroup>
+          <thead className="sticky top-0 bg-white z-10">
+            <tr className="bg-gray-100 text-left">
+              <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 relative">フィールド名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
+              <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 relative">データ型<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
+              <th ref={setThRef(2)} className="px-3 py-2 border border-gray-200 relative">種別<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(2)} /></th>
+              <th ref={setThRef(3)} className="px-3 py-2 border border-gray-200 relative">グローバル<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(3)} /></th>
+              <th ref={setThRef(4)} className="px-3 py-2 border border-gray-200 relative">繰り返し<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(4)} /></th>
+              <th ref={setThRef(5)} className="px-3 py-2 border border-gray-200 relative">計算式<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(5)} /></th>
+            </tr>
+          </thead>
+          <tbody>
+            {allRows.map((field) => {
                 const isSelected =
                   !field.isPhantom &&
                   rightPanel?.kind === "field" &&
@@ -190,8 +190,8 @@ export function TableDetail({ projectId, tableId, name }: Props) {
                     </td>
                   </tr>
                 );
-              })}
-            </tbody>
+            })}
+          </tbody>
           </table>
       )}
       </div>

--- a/src/components/detail/TableDetail.tsx
+++ b/src/components/detail/TableDetail.tsx
@@ -2,6 +2,7 @@
 import { useMemo } from "react";
 import { useTableFields, useTableList } from "../../hooks/table";
 import { useAppStore } from "../../stores/appStore";
+import { useColumnResize } from "../../hooks/useColumnResize";
 import type { FieldRow } from "../../types/ddr";
 import { Spinner } from "../Spinner";
 import { BADGE_VARIANTS } from "../../styles/tokens";
@@ -34,6 +35,7 @@ const DIFF_NAME_CLASS: Record<DiffKind, string> = {
 export function TableDetail({ projectId, tableId, name }: Props) {
   const { data: fields = [], isLoading } = useTableFields(projectId, tableId);
   const { rightPanel, setRightPanel, diffContext } = useAppStore();
+  const { widths, setThRef, getResizeHandleProps } = useColumnResize(6);
 
   // diff ハイライト用: 比較元プロジェクトのフィールドを取得
   const compareProjectId = diffContext?.compareProjectId ?? null;
@@ -94,43 +96,48 @@ export function TableDetail({ projectId, tableId, name }: Props) {
   }
 
   return (
-    <div className="p-4">
-      <h2 className="text-lg font-bold mb-4 text-gray-800">{name}</h2>
-      {compareProjectId && diffMap.size > 0 && (
-        <div className="flex gap-3 text-xs mb-3">
-          {[...new Set(diffMap.values())].includes("Added") && (
-            <span className="inline-flex items-center gap-1 text-green-700">
-              <span className="w-2 h-2 rounded-full bg-green-400 inline-block" />
-              追加
-            </span>
-          )}
-          {[...new Set(diffMap.values())].includes("Removed") && (
-            <span className="inline-flex items-center gap-1 text-red-600">
-              <span className="w-2 h-2 rounded-full bg-red-400 inline-block" />
-              削除
-            </span>
-          )}
-          {[...new Set(diffMap.values())].includes("Modified") && (
-            <span className="inline-flex items-center gap-1 text-yellow-700">
-              <span className="w-2 h-2 rounded-full bg-yellow-400 inline-block" />
-              変更
-            </span>
-          )}
-        </div>
-      )}
+    <div className="flex flex-col h-full">
+      <div className="px-4 pt-4 pb-2 shrink-0">
+        <h2 className="text-lg font-bold mb-2 text-gray-800">{name}</h2>
+        {compareProjectId && diffMap.size > 0 && (
+          <div className="flex gap-3 text-xs mb-1">
+            {[...new Set(diffMap.values())].includes("Added") && (
+              <span className="inline-flex items-center gap-1 text-green-700">
+                <span className="w-2 h-2 rounded-full bg-green-400 inline-block" />
+                追加
+              </span>
+            )}
+            {[...new Set(diffMap.values())].includes("Removed") && (
+              <span className="inline-flex items-center gap-1 text-red-600">
+                <span className="w-2 h-2 rounded-full bg-red-400 inline-block" />
+                削除
+              </span>
+            )}
+            {[...new Set(diffMap.values())].includes("Modified") && (
+              <span className="inline-flex items-center gap-1 text-yellow-700">
+                <span className="w-2 h-2 rounded-full bg-yellow-400 inline-block" />
+                変更
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="flex-1 overflow-auto [scrollbar-gutter:stable] px-4 pb-4">
       {allRows.length === 0 ? (
         <p className="text-gray-500">フィールドなし</p>
       ) : (
-        <div className="overflow-auto">
-          <table className="w-full text-sm border-collapse">
-            <thead>
+        <table className="w-full text-sm border-separate border-spacing-0 table-fixed [&_td]:overflow-hidden [&_th]:overflow-hidden">
+            <colgroup>
+              {widths.map((w, i) => <col key={i} style={w !== undefined ? { width: `${w}px` } : undefined} />)}
+            </colgroup>
+            <thead className="sticky top-0 bg-white z-10">
               <tr className="bg-gray-100 text-left">
-                <th className="px-3 py-2 border border-gray-200">フィールド名</th>
-                <th className="px-3 py-2 border border-gray-200">データ型</th>
-                <th className="px-3 py-2 border border-gray-200">種別</th>
-                <th className="px-3 py-2 border border-gray-200">グローバル</th>
-                <th className="px-3 py-2 border border-gray-200">繰り返し</th>
-                <th className="px-3 py-2 border border-gray-200">計算式</th>
+                <th ref={setThRef(0)} className="px-3 py-2 border border-gray-200 relative">フィールド名<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(0)} /></th>
+                <th ref={setThRef(1)} className="px-3 py-2 border border-gray-200 relative">データ型<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(1)} /></th>
+                <th ref={setThRef(2)} className="px-3 py-2 border border-gray-200 relative">種別<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(2)} /></th>
+                <th ref={setThRef(3)} className="px-3 py-2 border border-gray-200 relative">グローバル<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(3)} /></th>
+                <th ref={setThRef(4)} className="px-3 py-2 border border-gray-200 relative">繰り返し<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(4)} /></th>
+                <th ref={setThRef(5)} className="px-3 py-2 border border-gray-200 relative">計算式<div className="absolute inset-y-0 right-0 w-1 cursor-col-resize select-none hover:bg-blue-400" {...getResizeHandleProps(5)} /></th>
               </tr>
             </thead>
             <tbody>
@@ -186,8 +193,8 @@ export function TableDetail({ projectId, tableId, name }: Props) {
               })}
             </tbody>
           </table>
-        </div>
       )}
+      </div>
     </div>
   );
 }

--- a/src/components/detail/UpgradeCheckPanel.tsx
+++ b/src/components/detail/UpgradeCheckPanel.tsx
@@ -214,7 +214,7 @@ export function UpgradeCheckPanel({ solutionId }: Props) {
           {groups.length > 0 && (
             <div className={`${CARD} overflow-x-auto`}>
               <p className={`${SECTION_HEADER} mb-3`}>サマリー</p>
-              <table className="w-full text-xs border-collapse">
+              <table className="w-full text-xs border-separate border-spacing-0">
                 <thead>
                   <tr>
                     <th className="text-left py-1 pr-3 text-gray-500 font-medium whitespace-nowrap">チェック項目</th>

--- a/src/hooks/useColumnResize.ts
+++ b/src/hooks/useColumnResize.ts
@@ -1,0 +1,68 @@
+import { useRef, useState } from "react";
+
+/**
+ * テーブルの列幅をドラッグでリサイズするフック。
+ * table-layout:fixed の <colgroup> と組み合わせて使用する。
+ *
+ * ドラッグ開始時に全列幅を DOM から実測して一括固定し、
+ * N を広げると N+1 が狭まる（合計幅一定）。最終列のみ単独変更。
+ */
+export function useColumnResize(count: number) {
+  const [widths, setWidths] = useState<(number | undefined)[]>(() =>
+    Array(count).fill(undefined)
+  );
+  const thRefs = useRef<(HTMLTableCellElement | null)[]>(Array(count).fill(null));
+  const dragging = useRef<{
+    colIndex: number;
+    startX: number;
+    frozenWidths: number[];
+  } | null>(null);
+
+  const setThRef = (colIndex: number) => (el: HTMLTableCellElement | null) => {
+    thRefs.current[colIndex] = el;
+  };
+
+  const getResizeHandleProps = (colIndex: number) => ({
+    onMouseDown: (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // 全列の実測幅を取得して一括固定（auto列の再配分を防ぐ）
+      const frozenWidths = thRefs.current.map(
+        (th) => th?.offsetWidth ?? 100
+      ) as number[];
+      setWidths([...frozenWidths]);
+
+      dragging.current = { colIndex, startX: e.clientX, frozenWidths };
+
+      const onMouseMove = (ev: MouseEvent) => {
+        if (!dragging.current) return;
+        const { colIndex: idx, frozenWidths } = dragging.current;
+        const delta = ev.clientX - dragging.current.startX;
+        const newWidth = Math.max(40, frozenWidths[idx] + delta);
+        const actualDelta = newWidth - frozenWidths[idx];
+
+        // 常に frozenWidths を基準に計算（React state の非同期更新に依存しない）
+        setWidths(() => {
+          const next = [...frozenWidths];
+          next[idx] = newWidth;
+          if (idx + 1 < frozenWidths.length) {
+            next[idx + 1] = Math.max(40, frozenWidths[idx + 1] - actualDelta);
+          }
+          return next;
+        });
+      };
+
+      const onMouseUp = () => {
+        dragging.current = null;
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+      };
+
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+  });
+
+  return { widths, setThRef, getResizeHandleProps };
+}

--- a/src/hooks/useColumnResize.ts
+++ b/src/hooks/useColumnResize.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 
 /**
  * テーブルの列幅をドラッグでリサイズするフック。
@@ -18,9 +18,28 @@ export function useColumnResize(count: number) {
     frozenWidths: number[];
   } | null>(null);
 
-  const setThRef = (colIndex: number) => (el: HTMLTableCellElement | null) => {
-    thRefs.current[colIndex] = el;
-  };
+  // 安定したコールバックをマウント時に一度だけ生成（毎レンダーで新規生成しない）
+  const thRefCallbacks = useRef<((el: HTMLTableCellElement | null) => void)[]>(
+    Array.from({ length: count }, (_, i) => (el: HTMLTableCellElement | null) => {
+      thRefs.current[i] = el;
+    })
+  );
+
+  const setThRef = (colIndex: number) => thRefCallbacks.current[colIndex];
+
+  // アンマウント時にドラッグ中のリスナーを確実に除去する
+  const activeListeners = useRef<{
+    onMouseMove: ((ev: MouseEvent) => void) | null;
+    onMouseUp: (() => void) | null;
+  }>({ onMouseMove: null, onMouseUp: null });
+
+  useEffect(() => {
+    return () => {
+      const { onMouseMove, onMouseUp } = activeListeners.current;
+      if (onMouseMove) document.removeEventListener("mousemove", onMouseMove);
+      if (onMouseUp) document.removeEventListener("mouseup", onMouseUp);
+    };
+  }, []);
 
   const getResizeHandleProps = (colIndex: number) => ({
     onMouseDown: (e: React.MouseEvent) => {
@@ -55,10 +74,14 @@ export function useColumnResize(count: number) {
 
       const onMouseUp = () => {
         dragging.current = null;
+        activeListeners.current.onMouseMove = null;
+        activeListeners.current.onMouseUp = null;
         document.removeEventListener("mousemove", onMouseMove);
         document.removeEventListener("mouseup", onMouseUp);
       };
 
+      activeListeners.current.onMouseMove = onMouseMove;
+      activeListeners.current.onMouseUp = onMouseUp;
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
     },


### PR DESCRIPTION
## Summary

- `useColumnResize` フックを新規追加 — ドラッグで列幅変更（隣接列と合計幅一定、最小幅 40px）
- `All*Panel`（AllTablesPanel / AllFieldsPanel / AllScriptsPanel / AllLayoutsPanel / AllTableOccurrencesPanel / AllRelationshipsPanel / AllValueListsPanel / AllCustomFunctionsPanel / AllExternalDataSourcesPanel）に `table-fixed` + スティッキーヘッダー + リサイズハンドルを適用
- `TableDetail`: タイトルを `shrink-0` 固定ヘッダーに分離し、フィールドテーブルを `flex-1 overflow-auto` でスクロール可能に
- `LayoutDetail`: タイトル・テーブルオカレンス・スクリプトトリガー・オブジェクト一覧見出しを `shrink-0` 固定ヘッダーに集約し、オブジェクトテーブルのみスクロール
- `MainContent`: table / layout コンテナを `overflow-hidden flex flex-col` に変更（内部コンポーネントがスクロールを制御）

## Test plan

- [ ] `npm run test` — 359 tests passed
- [ ] `tsc --noEmit` — エラーなし
- [ ] `useColumnResize.test.ts` 5テスト追加（初期状態・ref登録・mousemoveでの幅変更・隣接列縮小・最小幅クランプ）
- [ ] 各 All*Panel でカラムヘッダーをドラッグして幅が変わることを確認
- [ ] TableDetail でフィールドが多いテーブルを開き、スクロール時にタイトルが固定されることを確認
- [ ] LayoutDetail でオブジェクトが多いレイアウトを開き、スクロール時にタイトル・トリガー・オブジェクト一覧見出しが固定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)