### PR TITLE
feat: 右パネルをデュアル化（パネル1・パネル2の独立スクロール＋自動昇格）

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -131,7 +131,8 @@ filemaker-ddr-viewer/
 | `selectedProject` | `ProjectRow \| null` | 現在選択中のプロジェクト |
 | `selectedElement` | `SelectedElement` | メインパネルに表示する要素（`null` を含むユニオン型） |
 | `searchQuery` | `string` | 検索バーのテキスト |
-| `rightPanel` | `RightPanelState` | 右パネルに表示する要素（`null` を含むユニオン型） |
+| `rightPanel` | `RightPanelState` | 右パネル1に表示する要素（`null` を含むユニオン型）。`setRightPanel` 呼び出し時に `rightPanel2` も自動クリア |
+| `rightPanel2` | `RightPanelState` | 右パネル2（フィールド詳細専用）。`LayoutObjectDetail` / `FieldCalcReferences` でフィールドリンクをクリックすると開く。パネル1が閉じると連動してクリア |
 | `navHistory` | `SelectedElement[]` | ←→ ナビゲーション履歴 |
 | `navIndex` | `number` | 履歴内の現在位置 |
 | `fontSize` | `number` | フォントサイズ（localStorage 永続化） |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,6 +121,23 @@ function FieldPanelInner({
   );
 }
 
+function RightPanel2Content({ width }: { width: number }) {
+  const { rightPanel2, setRightPanel2 } = useAppStore();
+  if (!rightPanel2 || rightPanel2.kind !== "field") return null;
+  const { projectId, fieldProjectId, tableId, tableName, fieldId } = rightPanel2;
+  return (
+    <FieldPanelInner
+      width={width}
+      projectId={projectId}
+      fieldProjectId={fieldProjectId}
+      tableId={tableId}
+      tableName={tableName}
+      fieldId={fieldId}
+      onClose={() => setRightPanel2(null)}
+    />
+  );
+}
+
 function App() {
   const {
     selectedElement,
@@ -128,6 +145,7 @@ function App() {
     showAbout,
     showUpgradeSettings,
     rightPanel,
+    rightPanel2,
     stepFontSize,
     setShowAbout,
     setShowUpgradeSettings,
@@ -140,7 +158,8 @@ function App() {
   } = useAppStore();
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT);
   const [rightPanelWidth, setRightPanelWidth] = useState(RIGHTPANEL_DEFAULT);
-  const isDragging = useRef<"left" | "right" | null>(null);
+  const [rightPanel2Width, setRightPanel2Width] = useState(RIGHTPANEL_DEFAULT);
+  const isDragging = useRef<"left" | "right" | "right2" | null>(null);
   const startX = useRef(0);
   const startWidth = useRef(0);
 
@@ -194,6 +213,14 @@ function App() {
     document.body.style.userSelect = "none";
   }, [rightPanelWidth]);
 
+  const onRight2DragStart = useCallback((e: React.MouseEvent) => {
+    isDragging.current = "right2";
+    startX.current = e.clientX;
+    startWidth.current = rightPanel2Width;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, [rightPanel2Width]);
+
   useEffect(() => {
     const onMove = (e: MouseEvent) => {
       if (!isDragging.current) return;
@@ -201,10 +228,13 @@ function App() {
       if (isDragging.current === "left") {
         const newWidth = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, startWidth.current + delta));
         setSidebarWidth(newWidth);
-      } else {
+      } else if (isDragging.current === "right") {
         // 右パネルは左へドラッグすると広がる（逆方向）
         const newWidth = Math.min(RIGHTPANEL_MAX, Math.max(RIGHTPANEL_MIN, startWidth.current - delta));
         setRightPanelWidth(newWidth);
+      } else if (isDragging.current === "right2") {
+        const newWidth = Math.min(RIGHTPANEL_MAX, Math.max(RIGHTPANEL_MIN, startWidth.current - delta));
+        setRightPanel2Width(newWidth);
       }
     };
     const onUp = () => {
@@ -302,6 +332,18 @@ function App() {
               <ErrorBoundary resetKey={rightPanel}>
                 <RightPanelContent width={rightPanelWidth} />
               </ErrorBoundary>
+              {/* パネル2（フィールド詳細） */}
+              {rightPanel2 && (
+                <>
+                  <div
+                    className="w-px cursor-col-resize bg-gray-200 hover:bg-blue-400 active:bg-blue-500 transition-colors shrink-0"
+                    onMouseDown={onRight2DragStart}
+                  />
+                  <ErrorBoundary resetKey={rightPanel2}>
+                    <RightPanel2Content width={rightPanel2Width} />
+                  </ErrorBoundary>
+                </>
+              )}
             </>
           )}
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,7 +123,7 @@ function FieldPanelInner({
 
 function RightPanel2Content({ width }: { width: number }) {
   const { rightPanel2, setRightPanel2 } = useAppStore();
-  if (!rightPanel2 || rightPanel2.kind !== "field") return null;
+  if (!rightPanel2) return null;
   const { projectId, fieldProjectId, tableId, tableName, fieldId } = rightPanel2;
   return (
     <FieldPanelInner

--- a/src/__tests__/detail/LayoutObjectDetail.test.tsx
+++ b/src/__tests__/detail/LayoutObjectDetail.test.tsx
@@ -34,6 +34,7 @@ const compareObj = {
 const mockLayout = makeLayoutRow({ id: 10, fm_id: 1, name: "ContactLayout", table_occurrence_name: "Contact" });
 
 const mockSetRightPanel = vi.fn();
+const mockSetRightPanel2 = vi.fn();
 
 function setupStore(diffContext: { compareProjectId: number } | null) {
   vi.mocked(useAppStore).mockReturnValue({
@@ -41,6 +42,7 @@ function setupStore(diffContext: { compareProjectId: number } | null) {
     selectedElement: { kind: "layout" as const, projectId: 1, id: 10, name: "ContactLayout" },
     diffContext,
     setRightPanel: mockSetRightPanel,
+    setRightPanel2: mockSetRightPanel2,
   } as unknown as ReturnType<typeof useAppStore>);
 }
 
@@ -115,7 +117,7 @@ describe("LayoutObjectDetail", () => {
     expect(screen.getByText(/位置/)).toBeInTheDocument();
   });
 
-  it("field_click_passes_field_project_id_to_set_right_panel", async () => {
+  it("field_click_calls_setRightPanel2_with_field_location", async () => {
     const { fireEvent } = await import("@testing-library/react");
     setupStore(null);
     vi.mocked(useResolveLayoutField).mockReturnValue({
@@ -124,7 +126,7 @@ describe("LayoutObjectDetail", () => {
     render(<LayoutObjectDetail layoutObjectId={1} layoutId={10} />);
     const btn = screen.getByRole("button", { name: /Contact::Name/ });
     fireEvent.click(btn);
-    expect(mockSetRightPanel).toHaveBeenCalledWith(
+    expect(mockSetRightPanel2).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: "field",
         fieldProjectId: 99,
@@ -132,6 +134,7 @@ describe("LayoutObjectDetail", () => {
         fieldId: 42,
       })
     );
+    expect(mockSetRightPanel).not.toHaveBeenCalled();
   });
 
   it("shows_tooltip_change_when_tooltip_differs", () => {

--- a/src/__tests__/detail/field/FieldCalcReferences.test.tsx
+++ b/src/__tests__/detail/field/FieldCalcReferences.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FieldCalcReferences } from "../../../components/detail/field/FieldCalcReferences";
+
+vi.mock("../../../hooks/fieldRefs", () => ({
+  useFieldCalcRefs: vi.fn(),
+}));
+vi.mock("../../../stores/appStore", () => ({
+  useAppStore: vi.fn(),
+}));
+
+import { useFieldCalcRefs } from "../../../hooks/fieldRefs";
+import { useAppStore } from "../../../stores/appStore";
+
+const mockSetRightPanel2 = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useAppStore).mockReturnValue({
+    setRightPanel2: mockSetRightPanel2,
+  } as unknown as ReturnType<typeof useAppStore>);
+});
+
+describe("FieldCalcReferences", () => {
+  it("shows_empty_message_when_no_refs", () => {
+    vi.mocked(useFieldCalcRefs).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useFieldCalcRefs>);
+    render(<FieldCalcReferences projectId={1} tableName="T" fieldName="F" />);
+    expect(screen.getByText(/他のフィールドの計算式で参照されていません/)).toBeInTheDocument();
+  });
+
+  it("shows_loading_state", () => {
+    vi.mocked(useFieldCalcRefs).mockReturnValue({
+      data: [],
+      isLoading: true,
+    } as unknown as ReturnType<typeof useFieldCalcRefs>);
+    render(<FieldCalcReferences projectId={1} tableName="T" fieldName="F" />);
+    expect(screen.getByText(/読み込み中/)).toBeInTheDocument();
+  });
+
+  it("click_calls_setRightPanel2_with_correct_args", () => {
+    vi.mocked(useFieldCalcRefs).mockReturnValue({
+      data: [{ field_id: 42, field_name: "CalcField", table_name: "Customer", table_id: 5, project_id: 99 }],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useFieldCalcRefs>);
+    render(<FieldCalcReferences projectId={1} tableName="T" fieldName="F" />);
+    fireEvent.click(screen.getByRole("button", { name: "Customer::CalcField" }));
+    expect(mockSetRightPanel2).toHaveBeenCalledWith({
+      kind: "field",
+      projectId: 99,
+      fieldProjectId: 99,
+      tableId: 5,
+      fieldId: 42,
+      tableName: "Customer",
+    });
+  });
+});

--- a/src/__tests__/stores/appStore.test.ts
+++ b/src/__tests__/stores/appStore.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAppStore } from "../../stores/appStore";
+
+beforeEach(() => {
+  useAppStore.setState({
+    rightPanel: null,
+    rightPanel2: null,
+  } as Parameters<typeof useAppStore.setState>[0]);
+});
+
+describe("appStore - setRightPanel", () => {
+  it("setRightPanel が rightPanel2 を null にクリアする", () => {
+    useAppStore.setState({
+      rightPanel2: { kind: "field", fieldId: 1, tableId: 2, projectId: 3, tableName: "T" },
+    } as Parameters<typeof useAppStore.setState>[0]);
+
+    useAppStore.getState().setRightPanel({ kind: "layout_object", layoutObjectId: 10, layoutId: 1 });
+
+    expect(useAppStore.getState().rightPanel2).toBeNull();
+  });
+
+  it("setRightPanel(null) でパネル1・パネル2 両方がクリアされる", () => {
+    useAppStore.setState({
+      rightPanel: { kind: "layout_object", layoutObjectId: 10, layoutId: 1 },
+      rightPanel2: { kind: "field", fieldId: 1, tableId: 2, projectId: 3, tableName: "T" },
+    } as Parameters<typeof useAppStore.setState>[0]);
+
+    useAppStore.getState().setRightPanel(null);
+
+    expect(useAppStore.getState().rightPanel).toBeNull();
+    expect(useAppStore.getState().rightPanel2).toBeNull();
+  });
+
+  it("setRightPanel2 が rightPanel2 のみ更新する", () => {
+    const panel1 = { kind: "layout_object" as const, layoutObjectId: 10, layoutId: 1 };
+    useAppStore.setState({ rightPanel: panel1 } as Parameters<typeof useAppStore.setState>[0]);
+
+    useAppStore.getState().setRightPanel2({ kind: "field", fieldId: 5, tableId: 6, projectId: 7, tableName: "X" });
+
+    expect(useAppStore.getState().rightPanel).toEqual(panel1);
+    expect(useAppStore.getState().rightPanel2).toEqual(
+      expect.objectContaining({ kind: "field", fieldId: 5 })
+    );
+  });
+});

--- a/src/__tests__/stores/appStore.test.ts
+++ b/src/__tests__/stores/appStore.test.ts
@@ -1,11 +1,74 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useAppStore } from "../../stores/appStore";
+import type { SelectedElement } from "../../stores/appStore";
 
 beforeEach(() => {
   useAppStore.setState({
     rightPanel: null,
     rightPanel2: null,
   } as Parameters<typeof useAppStore.setState>[0]);
+});
+
+const panel1 = { kind: "layout_object" as const, layoutObjectId: 10, layoutId: 1 };
+const panel2 = { kind: "field" as const, fieldId: 5, tableId: 6, projectId: 7, tableName: "X" };
+const mockProject = { id: 1, name: "P", file_path: null, fm_version: "19", imported_at: "" };
+const mockSolution = { id: 1, name: "S", summary_path: null, imported_at: "" };
+
+describe("appStore - パネル自動クリア（メイン遷移時）", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      rightPanel: panel1,
+      rightPanel2: panel2,
+      navHistory: [] as SelectedElement[],
+      navIndex: -1,
+      selectedElement: null,
+      searchQuery: "",
+    } as Parameters<typeof useAppStore.setState>[0]);
+  });
+
+  it("selectElement: Panel 2 が開いているとき Panel 2 が Panel 1 に昇格し Panel 2 が null になる", () => {
+    useAppStore.getState().selectElement({ kind: "script", projectId: 1, id: 1, name: "Script" });
+    expect(useAppStore.getState().rightPanel).toEqual(panel2);
+    expect(useAppStore.getState().rightPanel2).toBeNull();
+  });
+
+  it("selectElement: Panel 1 のみ開いているとき Panel 1 が null になる", () => {
+    useAppStore.setState({ rightPanel2: null } as Parameters<typeof useAppStore.setState>[0]);
+    useAppStore.getState().selectElement({ kind: "script", projectId: 1, id: 1, name: "Script" });
+    expect(useAppStore.getState().rightPanel).toBeNull();
+    expect(useAppStore.getState().rightPanel2).toBeNull();
+  });
+
+  it("selectElement: パネルなしのとき rightPanel は null のまま", () => {
+    useAppStore.setState({ rightPanel: null, rightPanel2: null } as Parameters<typeof useAppStore.setState>[0]);
+    useAppStore.getState().selectElement({ kind: "script", projectId: 1, id: 1, name: "Script" });
+    expect(useAppStore.getState().rightPanel).toBeNull();
+    expect(useAppStore.getState().rightPanel2).toBeNull();
+  });
+
+  it("navigateFromDiff: Panel 2 が開いているとき Panel 2 が Panel 1 に昇格する", () => {
+    useAppStore.getState().navigateFromDiff({ kind: "script", projectId: 1, id: 1, name: "Script" }, 2);
+    expect(useAppStore.getState().rightPanel).toEqual(panel2);
+    expect(useAppStore.getState().rightPanel2).toBeNull();
+  });
+
+  it("selectProject: 両パネルが閉じる", () => {
+    useAppStore.getState().selectProject(mockProject);
+    expect(useAppStore.getState().rightPanel).toBeNull();
+    expect(useAppStore.getState().rightPanel2).toBeNull();
+  });
+
+  it("selectSolution: 両パネルが閉じる", () => {
+    useAppStore.getState().selectSolution(mockSolution);
+    expect(useAppStore.getState().rightPanel).toBeNull();
+    expect(useAppStore.getState().rightPanel2).toBeNull();
+  });
+
+  it("navigateToProject: 両パネルが閉じる", () => {
+    useAppStore.getState().navigateToProject(mockProject);
+    expect(useAppStore.getState().rightPanel).toBeNull();
+    expect(useAppStore.getState().rightPanel2).toBeNull();
+  });
 });
 
 describe("appStore - setRightPanel", () => {

--- a/src/components/detail/LayoutObjectDetail.tsx
+++ b/src/components/detail/LayoutObjectDetail.tsx
@@ -16,7 +16,7 @@ export function LayoutObjectDetail({ layoutObjectId, layoutId }: Props) {
   const { data: objects = [], isLoading } = useLayoutObjects(layoutId);
   const obj = objects.find((o) => o.id === layoutObjectId);
 
-  const { selectedProject, selectedElement, diffContext, setRightPanel } = useAppStore();
+  const { selectedProject, selectedElement, diffContext, setRightPanel2 } = useAppStore();
   const projectId = selectedProject?.id ?? null;
 
   const { data: conditions = [] } = useLayoutObjectConditions(obj?.id ?? null);
@@ -111,7 +111,7 @@ export function LayoutObjectDetail({ layoutObjectId, layoutId }: Props) {
             <button
               className="text-blue-700 font-medium hover:underline text-left"
               onClick={() =>
-                setRightPanel({
+                setRightPanel2({
                   kind: "field",
                   projectId,
                   fieldProjectId: fieldLocation.field_project_id,

--- a/src/components/detail/field/FieldCalcReferences.tsx
+++ b/src/components/detail/field/FieldCalcReferences.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export function FieldCalcReferences({ projectId, tableName, fieldName }: Props) {
-  const { setRightPanel } = useAppStore();
+  const { setRightPanel2 } = useAppStore();
   const { data: calcRefs = [], isLoading } = useFieldCalcRefs(
     projectId,
     tableName,
@@ -34,7 +34,7 @@ export function FieldCalcReferences({ projectId, tableName, fieldName }: Props) 
               <button
                 className="text-blue-600 hover:underline text-left break-all w-full"
                 onClick={() =>
-                  setRightPanel({
+                  setRightPanel2({
                     kind: "field",
                     projectId: ref.project_id,
                     fieldProjectId: ref.project_id,

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -105,6 +105,8 @@ export type RightPanelState =
   | { kind: "layout_object"; layoutObjectId: number; layoutId: number }
   | null;
 
+export type FieldRightPanelState = Extract<RightPanelState, { kind: "field" }> | null;
+
 /** SelectedElement の同一性を O(1) で比較するためのキー文字列を返す。 */
 function elementKey(el: SelectedElement | undefined): string {
   if (el == null) return "null"; // null と undefined の両方を捕捉
@@ -167,7 +169,7 @@ interface AppState {
   showAbout: boolean;
   showUpgradeSettings: boolean;
   rightPanel: RightPanelState;
-  rightPanel2: RightPanelState;
+  rightPanel2: FieldRightPanelState;
   navHistory: SelectedElement[];
   navIndex: number;
   diffState: DiffStateData;
@@ -194,7 +196,7 @@ interface AppState {
   setShowAbout: (show: boolean) => void;
   setShowUpgradeSettings: (show: boolean) => void;
   setRightPanel: (panel: RightPanelState) => void;
-  setRightPanel2: (panel: RightPanelState) => void;
+  setRightPanel2: (panel: FieldRightPanelState) => void;
   navigateBack: () => void;
   navigateForward: () => void;
   purgeProjectFromHistory: (projectId: number) => void;

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -246,10 +246,12 @@ export const useAppStore = create<AppState>((set) => ({
       navIndex: dashboardEl ? 0 : -1,
       diffContext: null,
       diffState: { ...INITIAL_DIFF_STATE, solA: solution?.id ?? null },
+      rightPanel: null,
+      rightPanel2: null,
     });
   },
   selectProject: (project) =>
-    set({ selectedProject: project, selectedElement: null, diffContext: null }),
+    set({ selectedProject: project, selectedElement: null, diffContext: null, rightPanel: null, rightPanel2: null }),
   selectElement: (element) =>
     set((state) => {
       // 同じ要素なら履歴に積まない
@@ -285,6 +287,9 @@ export const useAppStore = create<AppState>((set) => ({
         navHistory: newHistory,
         navIndex: newHistory.length - 1,
         diffContext: null,
+        // Panel 2 があれば Panel 1 に昇格、なければ Panel 1 も閉じる
+        rightPanel: state.rightPanel2 ?? null,
+        rightPanel2: null,
       };
     }),
   navigateFromDiff: (element, compareProjectId) =>
@@ -316,6 +321,9 @@ export const useAppStore = create<AppState>((set) => ({
         navHistory: newHistory,
         navIndex: newHistory.length - 1,
         diffContext: { compareProjectId },
+        // Panel 2 があれば Panel 1 に昇格、なければ Panel 1 も閉じる
+        rightPanel: state.rightPanel2 ?? null,
+        rightPanel2: null,
       };
     }),
   setDiffState: (diffState) => set({ diffState }),
@@ -402,6 +410,8 @@ export const useAppStore = create<AppState>((set) => ({
         navHistory: baseHistory,
         navIndex: baseHistory.length - 1,
         diffContext: null,
+        rightPanel: null,
+        rightPanel2: null,
       };
     }),
 }));

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -167,6 +167,7 @@ interface AppState {
   showAbout: boolean;
   showUpgradeSettings: boolean;
   rightPanel: RightPanelState;
+  rightPanel2: RightPanelState;
   navHistory: SelectedElement[];
   navIndex: number;
   diffState: DiffStateData;
@@ -193,6 +194,7 @@ interface AppState {
   setShowAbout: (show: boolean) => void;
   setShowUpgradeSettings: (show: boolean) => void;
   setRightPanel: (panel: RightPanelState) => void;
+  setRightPanel2: (panel: RightPanelState) => void;
   navigateBack: () => void;
   navigateForward: () => void;
   purgeProjectFromHistory: (projectId: number) => void;
@@ -209,6 +211,7 @@ export const useAppStore = create<AppState>((set) => ({
   showAbout: false,
   showUpgradeSettings: false,
   rightPanel: null,
+  rightPanel2: null,
   navHistory: [],
   navIndex: -1,
   diffState: INITIAL_DIFF_STATE,
@@ -342,7 +345,8 @@ export const useAppStore = create<AppState>((set) => ({
     }),
   setShowAbout: (show) => set({ showAbout: show }),
   setShowUpgradeSettings: (show) => set({ showUpgradeSettings: show }),
-  setRightPanel: (panel) => set({ rightPanel: panel }),
+  setRightPanel: (panel) => set({ rightPanel: panel, rightPanel2: null }),
+  setRightPanel2: (panel) => set({ rightPanel2: panel }),
   navigateBack: () =>
     set((state) => {
       if (state.navIndex <= 0) return {};


### PR DESCRIPTION
Closes #49

## Summary

- **デュアル右パネル実装**: 右パネルをパネル1・パネル2の2枚構成にし、独立スクロール・独立ドラッグリサイズに対応
- **パネル開閉ロジック**:
  - `LayoutObjectDetail` / `FieldCalcReferences` でフィールドリンクをクリック → パネル2（フィールド詳細）が開く
  - パネル1を閉じると連動してパネル2もクリア（`setRightPanel` の既存挙動）
- **メイン遷移時の自動昇格**: `selectElement` / `navigateFromDiff` でメイン画面が切り替わるとき、パネル2（フィールド詳細）をパネル1へ昇格させる。スクリプト等を参照しながらフィールド詳細を見続けられる
- **コンテキスト全切り替え時**: `selectProject` / `selectSolution` / `navigateToProject` では両パネルをクリア

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/stores/appStore.ts` | `rightPanel2` 状態・`setRightPanel2` アクション追加、各ナビゲーションアクションにパネル制御ロジック追加 |
| `src/App.tsx` | パネル2の描画・ドラッグリサイズハンドル追加 |
| `src/components/detail/LayoutObjectDetail.tsx` | フィールドリンクで `setRightPanel2` 呼び出し |
| `src/components/detail/field/FieldCalcReferences.tsx` | フィールドリンクで `setRightPanel2` 呼び出し |
| `src/__tests__/stores/appStore.test.ts` | パネル自動クリア・昇格の全ケースをテスト |
| `src/__tests__/detail/LayoutObjectDetail.test.tsx` | `setRightPanel2` 呼び出しのテスト |

## Test plan

- [ ] `npm run test` → 369 passed ✅
- [ ] `tsc --noEmit` → エラーなし ✅
- [ ] レイアウト → オブジェクト行クリック → パネル1（オブジェクト詳細）が開く
- [ ] パネル1内のフィールドリンクをクリック → パネル2（フィールド詳細）が開き、パネル1が残る
- [ ] パネル2内のスクリプトリンクをクリック → メインがスクリプト画面、パネル2がパネル1に昇格
- [ ] パネル1の × → 両パネルが閉じる
- [ ] パネル2の × → パネル2のみ閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)