### PR TITLE
feat: ソリューション名をホバー鉛筆ボタンからインライン変更（Issue #52）

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,7 +87,7 @@ filemaker-ddr-viewer/
 | `MainContent.tsx` | メインエリアのルーティング（`selectedElement.kind` で切り替え） |
 | `navigation/CategoryTree.tsx` | サイドバーツリー。カテゴリ展開時のみ IPC クエリを発行（遅延ロード）。カウントは `useProjectSummary` から取得し未展開時も正確な値を表示 |
 | `SearchBar.tsx` / `SearchResults.tsx` | 全文検索・カテゴリフィルター・クリック遷移 |
-| `SolutionList.tsx` | ソリューション一覧・削除 |
+| `SolutionList.tsx` | ソリューション一覧・削除・プロジェクト名変更（ホバー鉛筆ボタン＋インライン編集） |
 | `ImportButton.tsx` | `概要.xml` インポート |
 | `ProjectSummaryCard.tsx` | 要素数サマリー（プロジェクト単位） |
 | `SolutionDashboard.tsx` | ソリューション選択時のサマリー（配下プロジェクト一覧） |
@@ -320,6 +320,7 @@ FM17〜22 の実 DDR サンプルを調査した結果、タグ名・構造に�
 | `delete_solution` | analysis.rs | `solution_id` | `()` |
 | `list_projects` | analysis.rs | — | `Vec<ProjectRow>` |
 | `delete_project` | analysis.rs | `project_id` | `()` |
+| `rename_project` | analysis.rs | `project_id, new_name` | `()` |
 | `get_project_summary` | analysis.rs | `project_id` | `ProjectSummary` |
 | `list_solution_project_summaries` | analysis.rs | `solution_id` | `Vec<ProjectSummary>` |
 | `get_broken_refs` | analysis.rs | `project_id` | `Vec<BrokenRef>` |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,7 +87,7 @@ filemaker-ddr-viewer/
 | `MainContent.tsx` | メインエリアのルーティング（`selectedElement.kind` で切り替え） |
 | `navigation/CategoryTree.tsx` | サイドバーツリー。カテゴリ展開時のみ IPC クエリを発行（遅延ロード）。カウントは `useProjectSummary` から取得し未展開時も正確な値を表示 |
 | `SearchBar.tsx` / `SearchResults.tsx` | 全文検索・カテゴリフィルター・クリック遷移 |
-| `SolutionList.tsx` | ソリューション一覧・削除・プロジェクト名変更（ホバー鉛筆ボタン＋インライン編集） |
+| `SolutionList.tsx` | ソリューション一覧・削除・ソリューション名変更（ホバー鉛筆ボタン＋インライン編集） |
 | `ImportButton.tsx` | `概要.xml` インポート |
 | `ProjectSummaryCard.tsx` | 要素数サマリー（プロジェクト単位） |
 | `SolutionDashboard.tsx` | ソリューション選択時のサマリー（配下プロジェクト一覧） |
@@ -320,7 +320,7 @@ FM17〜22 の実 DDR サンプルを調査した結果、タグ名・構造に�
 | `delete_solution` | analysis.rs | `solution_id` | `()` |
 | `list_projects` | analysis.rs | — | `Vec<ProjectRow>` |
 | `delete_project` | analysis.rs | `project_id` | `()` |
-| `rename_project` | analysis.rs | `project_id, new_name` | `()` |
+| `rename_solution` | analysis.rs | `solution_id, new_name` | `()` |
 | `get_project_summary` | analysis.rs | `project_id` | `ProjectSummary` |
 | `list_solution_project_summaries` | analysis.rs | `solution_id` | `Vec<ProjectSummary>` |
 | `get_broken_refs` | analysis.rs | `project_id` | `Vec<BrokenRef>` |

--- a/src-tauri/src/commands/analysis.rs
+++ b/src-tauri/src/commands/analysis.rs
@@ -13,7 +13,8 @@ use crate::{
         repository::{
             delete_project as db_delete_project, delete_solution as db_delete_solution,
             get_project, list_projects as db_list_projects, list_solutions as db_list_solutions,
-            run_upgrade_check, CheckItemConfig, ProjectRow, SolutionRow, UpgradeHit,
+            run_upgrade_check, update_project_name as db_update_project_name, CheckItemConfig,
+            ProjectRow, SolutionRow, UpgradeHit,
         },
         Database,
     },
@@ -137,6 +138,17 @@ pub async fn delete_project(
 ) -> Result<(), CommandError> {
     let mut db = super::lock_db(&state)?;
     db_delete_project(&mut db, project_id).map_err(CommandError::from)
+}
+
+/// プロジェクト名を変更する。
+#[tauri::command]
+pub async fn rename_project(
+    state: tauri::State<'_, AppState>,
+    project_id: i64,
+    new_name: String,
+) -> Result<(), CommandError> {
+    let mut db = super::lock_db(&state)?;
+    db_update_project_name(&mut db, project_id, &new_name).map_err(CommandError::from)
 }
 
 /// プロジェクトの統計サマリーを返す。

--- a/src-tauri/src/commands/analysis.rs
+++ b/src-tauri/src/commands/analysis.rs
@@ -13,7 +13,7 @@ use crate::{
         repository::{
             delete_project as db_delete_project, delete_solution as db_delete_solution,
             get_project, list_projects as db_list_projects, list_solutions as db_list_solutions,
-            run_upgrade_check, update_project_name as db_update_project_name, CheckItemConfig,
+            run_upgrade_check, update_solution_name as db_update_solution_name, CheckItemConfig,
             ProjectRow, SolutionRow, UpgradeHit,
         },
         Database,
@@ -140,15 +140,15 @@ pub async fn delete_project(
     db_delete_project(&mut db, project_id).map_err(CommandError::from)
 }
 
-/// プロジェクト名を変更する。
+/// ソリューション名を変更する。
 #[tauri::command]
-pub async fn rename_project(
+pub async fn rename_solution(
     state: tauri::State<'_, AppState>,
-    project_id: i64,
+    solution_id: i64,
     new_name: String,
 ) -> Result<(), CommandError> {
     let mut db = super::lock_db(&state)?;
-    db_update_project_name(&mut db, project_id, &new_name).map_err(CommandError::from)
+    db_update_solution_name(&mut db, solution_id, &new_name).map_err(CommandError::from)
 }
 
 /// プロジェクトの統計サマリーを返す。

--- a/src-tauri/src/db/repository/mod.rs
+++ b/src-tauri/src/db/repository/mod.rs
@@ -18,7 +18,8 @@ mod solution;
 
 pub use solution::{
     delete_project, delete_solution, get_project, get_solution, get_solution_projects,
-    insert_solution, list_projects, list_solutions, ProjectRow, SolutionRow, SolutionWithProjects,
+    insert_solution, list_projects, list_solutions, update_project_name, ProjectRow, SolutionRow,
+    SolutionWithProjects,
 };
 
 pub use import::{insert_ddr_file, insert_layout_object_condition};

--- a/src-tauri/src/db/repository/mod.rs
+++ b/src-tauri/src/db/repository/mod.rs
@@ -18,7 +18,7 @@ mod solution;
 
 pub use solution::{
     delete_project, delete_solution, get_project, get_solution, get_solution_projects,
-    insert_solution, list_projects, list_solutions, update_project_name, ProjectRow, SolutionRow,
+    insert_solution, list_projects, list_solutions, update_solution_name, ProjectRow, SolutionRow,
     SolutionWithProjects,
 };
 

--- a/src-tauri/src/db/repository/solution.rs
+++ b/src-tauri/src/db/repository/solution.rs
@@ -178,6 +178,22 @@ pub fn get_project(db: &Database, project_id: i64) -> Result<ProjectRow, DbError
         })
 }
 
+/// プロジェクト名を更新する。
+pub fn update_project_name(
+    db: &mut Database,
+    project_id: i64,
+    new_name: &str,
+) -> Result<(), DbError> {
+    let affected = db.conn.execute(
+        "UPDATE projects SET name = ?1 WHERE id = ?2",
+        params![new_name, project_id],
+    )?;
+    if affected == 0 {
+        return Err(DbError::NotFound(format!("project:{project_id}")));
+    }
+    Ok(())
+}
+
 /// プロジェクトを CASCADE 削除する（関連データも全削除）。
 pub fn delete_project(db: &mut Database, project_id: i64) -> Result<(), DbError> {
     // FTS5 仮想テーブルは CASCADE DELETE に対応しないため手動で削除する
@@ -306,5 +322,21 @@ mod tests {
     fn delete_project_not_found_returns_err() {
         let mut db = Database::open_in_memory().unwrap();
         assert!(delete_project(&mut db, 9999).is_err());
+    }
+
+    // ---- update_project_name ----
+
+    #[test]
+    fn update_project_name_changes_name() {
+        let (mut db, _sid, pid) = db_with_minimal();
+        update_project_name(&mut db, pid, "新しい名前").unwrap();
+        let row = get_project(&db, pid).unwrap();
+        assert_eq!(row.name, "新しい名前");
+    }
+
+    #[test]
+    fn update_project_name_not_found_returns_err() {
+        let mut db = Database::open_in_memory().unwrap();
+        assert!(update_project_name(&mut db, 9999, "X").is_err());
     }
 }

--- a/src-tauri/src/db/repository/solution.rs
+++ b/src-tauri/src/db/repository/solution.rs
@@ -178,18 +178,18 @@ pub fn get_project(db: &Database, project_id: i64) -> Result<ProjectRow, DbError
         })
 }
 
-/// プロジェクト名を更新する。
-pub fn update_project_name(
+/// ソリューション名を更新する。
+pub fn update_solution_name(
     db: &mut Database,
-    project_id: i64,
+    solution_id: i64,
     new_name: &str,
 ) -> Result<(), DbError> {
     let affected = db.conn.execute(
-        "UPDATE projects SET name = ?1 WHERE id = ?2",
-        params![new_name, project_id],
+        "UPDATE solutions SET name = ?1 WHERE id = ?2",
+        params![new_name, solution_id],
     )?;
     if affected == 0 {
-        return Err(DbError::NotFound(format!("project:{project_id}")));
+        return Err(DbError::NotFound(format!("solution:{solution_id}")));
     }
     Ok(())
 }
@@ -324,19 +324,20 @@ mod tests {
         assert!(delete_project(&mut db, 9999).is_err());
     }
 
-    // ---- update_project_name ----
+    // ---- update_solution_name ----
 
     #[test]
-    fn update_project_name_changes_name() {
-        let (mut db, _sid, pid) = db_with_minimal();
-        update_project_name(&mut db, pid, "新しい名前").unwrap();
-        let row = get_project(&db, pid).unwrap();
-        assert_eq!(row.name, "新しい名前");
+    fn update_solution_name_changes_name() {
+        let mut db = Database::open_in_memory().unwrap();
+        let sid = insert_solution(&mut db, "OldName", None).unwrap();
+        update_solution_name(&mut db, sid, "NewName").unwrap();
+        let row = get_solution(&db, sid).unwrap();
+        assert_eq!(row.name, "NewName");
     }
 
     #[test]
-    fn update_project_name_not_found_returns_err() {
+    fn update_solution_name_not_found_returns_err() {
         let mut db = Database::open_in_memory().unwrap();
-        assert!(update_project_name(&mut db, 9999, "X").is_err());
+        assert!(update_solution_name(&mut db, 9999, "X").is_err());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -147,6 +147,7 @@ pub fn run() {
             commands::analysis::delete_solution,
             commands::analysis::list_projects,
             commands::analysis::delete_project,
+            commands::analysis::rename_project,
             commands::analysis::get_project_summary,
             commands::analysis::list_solution_project_summaries,
             commands::analysis::get_broken_refs,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -147,7 +147,7 @@ pub fn run() {
             commands::analysis::delete_solution,
             commands::analysis::list_projects,
             commands::analysis::delete_project,
-            commands::analysis::rename_project,
+            commands::analysis::rename_solution,
             commands::analysis::get_project_summary,
             commands::analysis::list_solution_project_summaries,
             commands::analysis::get_broken_refs,

--- a/src/__tests__/SolutionList.test.tsx
+++ b/src/__tests__/SolutionList.test.tsx
@@ -308,4 +308,67 @@ describe("SolutionList", () => {
       expect.objectContaining({ onSuccess: expect.any(Function) })
     );
   });
+
+  it("rename_blur_confirms_rename", () => {
+    const mutateMock = vi.fn();
+    vi.mocked(useRenameSolution).mockReturnValue(
+      { mutate: mutateMock, isPending: false } as unknown as ReturnType<typeof useRenameSolution>
+    );
+    vi.mocked(useSolutions).mockReturnValue(
+      { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
+    );
+    render(<SolutionList />);
+    const renameButtons = screen.getAllByRole("button", { name: "名前を変更" });
+    fireEvent.click(renameButtons[0]);
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "新しい名前" } });
+    fireEvent.blur(input);
+    expect(mutateMock).toHaveBeenCalledWith(
+      { solutionId: 1, newName: "新しい名前" },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+
+  it("rename_blur_without_change_does_not_mutate", () => {
+    const mutateMock = vi.fn();
+    vi.mocked(useRenameSolution).mockReturnValue(
+      { mutate: mutateMock, isPending: false } as unknown as ReturnType<typeof useRenameSolution>
+    );
+    vi.mocked(useSolutions).mockReturnValue(
+      { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
+    );
+    render(<SolutionList />);
+    const renameButtons = screen.getAllByRole("button", { name: "名前を変更" });
+    fireEvent.click(renameButtons[0]);
+    const input = screen.getByRole("textbox");
+    fireEvent.blur(input);
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it("rename_pencil_hidden_during_edit", () => {
+    vi.mocked(useSolutions).mockReturnValue(
+      { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
+    );
+    render(<SolutionList />);
+    expect(screen.getAllByRole("button", { name: "名前を変更" })).toHaveLength(2);
+    fireEvent.click(screen.getAllByRole("button", { name: "名前を変更" })[0]);
+    expect(screen.queryAllByRole("button", { name: "名前を変更" })).toHaveLength(1);
+  });
+
+  it("rename_escape_does_not_call_mutation", () => {
+    const mutateMock = vi.fn();
+    vi.mocked(useRenameSolution).mockReturnValue(
+      { mutate: mutateMock, isPending: false } as unknown as ReturnType<typeof useRenameSolution>
+    );
+    vi.mocked(useSolutions).mockReturnValue(
+      { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
+    );
+    render(<SolutionList />);
+    const renameButtons = screen.getAllByRole("button", { name: "名前を変更" });
+    fireEvent.click(renameButtons[0]);
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "新しい名前" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/SolutionList.test.tsx
+++ b/src/__tests__/SolutionList.test.tsx
@@ -9,6 +9,7 @@ vi.mock("../hooks/solutions", () => ({
   useSolutionProjects: vi.fn(),
   useDeleteProject: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useRenameProject: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useRenameSolution: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("../stores/appStore", () => ({
@@ -20,7 +21,7 @@ vi.mock("../components/navigation/CategoryTree", () => ({
   CategoryTree: () => null,
 }));
 
-import { useSolutions, useDeleteSolution, useSolutionProjects, useDeleteProject, useRenameProject } from "../hooks/solutions";
+import { useSolutions, useDeleteSolution, useSolutionProjects, useDeleteProject, useRenameSolution } from "../hooks/solutions";
 import { useAppStore } from "../stores/appStore";
 
 const mockSolutions: SolutionRow[] = [
@@ -32,7 +33,7 @@ const mockSelectSolution = vi.fn();
 const mockSelectProject = vi.fn();
 const mockSelectElement = vi.fn();
 const mockSetRightPanel = vi.fn();
-const mockRenameProjectInStore = vi.fn();
+const mockRenameSolutionInStore = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -43,7 +44,7 @@ beforeEach(() => {
     selectProject: mockSelectProject,
     selectElement: mockSelectElement,
     setRightPanel: mockSetRightPanel,
-    renameProjectInStore: mockRenameProjectInStore,
+    renameSolutionInStore: mockRenameSolutionInStore,
   } as unknown as ReturnType<typeof useAppStore>);
   vi.mocked(useDeleteSolution).mockReturnValue(
     { mutate: vi.fn(), isPending: false } as unknown as ReturnType<typeof useDeleteSolution>
@@ -251,7 +252,6 @@ describe("SolutionList", () => {
       selectProject: mockSelectProject,
       selectElement: mockSelectElement,
       setRightPanel: mockSetRightPanel,
-      renameProjectInStore: mockRenameProjectInStore,
     } as unknown as ReturnType<typeof useAppStore>);
     vi.mocked(useSolutions).mockReturnValue(
       { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
@@ -266,81 +266,45 @@ describe("SolutionList", () => {
     expect(mockSelectProject).toHaveBeenCalledWith(mockProject);
   });
 
-  it("rename_button_shows_inline_input", () => {
-    const mockProject = { id: 10, name: "MyDB", fm_version: "19", file_path: "", imported_at: "" };
-    vi.mocked(useAppStore).mockReturnValue({
-      selectedSolution: mockSolutions[0],
-      selectedProject: null,
-      selectSolution: mockSelectSolution,
-      selectProject: mockSelectProject,
-      selectElement: mockSelectElement,
-      setRightPanel: mockSetRightPanel,
-      renameProjectInStore: mockRenameProjectInStore,
-    } as unknown as ReturnType<typeof useAppStore>);
+  it("rename_solution_button_shows_inline_input", () => {
     vi.mocked(useSolutions).mockReturnValue(
       { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
     );
-    vi.mocked(useSolutionProjects).mockReturnValue(
-      { data: [mockProject], isLoading: false } as unknown as ReturnType<typeof useSolutionProjects>
-    );
     render(<SolutionList />);
-    fireEvent.click(screen.getByRole("button", { name: "名前を変更" }));
+    const renameButtons = screen.getAllByRole("button", { name: "名前を変更" });
+    fireEvent.click(renameButtons[0]);
     expect(screen.getByRole("textbox")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("MyDB")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Solution A")).toBeInTheDocument();
   });
 
-  it("rename_escape_cancels_edit", () => {
-    const mockProject = { id: 10, name: "MyDB", fm_version: "19", file_path: "", imported_at: "" };
-    vi.mocked(useAppStore).mockReturnValue({
-      selectedSolution: mockSolutions[0],
-      selectedProject: null,
-      selectSolution: mockSelectSolution,
-      selectProject: mockSelectProject,
-      selectElement: mockSelectElement,
-      setRightPanel: mockSetRightPanel,
-      renameProjectInStore: mockRenameProjectInStore,
-    } as unknown as ReturnType<typeof useAppStore>);
+  it("rename_solution_escape_cancels_edit", () => {
     vi.mocked(useSolutions).mockReturnValue(
       { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
     );
-    vi.mocked(useSolutionProjects).mockReturnValue(
-      { data: [mockProject], isLoading: false } as unknown as ReturnType<typeof useSolutionProjects>
-    );
     render(<SolutionList />);
-    fireEvent.click(screen.getByRole("button", { name: "名前を変更" }));
+    const renameButtons = screen.getAllByRole("button", { name: "名前を変更" });
+    fireEvent.click(renameButtons[0]);
     expect(screen.getByRole("textbox")).toBeInTheDocument();
     fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
-  it("rename_enter_calls_mutation_with_new_name", () => {
+  it("rename_solution_enter_calls_mutation", () => {
     const mutateMock = vi.fn();
-    vi.mocked(useRenameProject).mockReturnValue(
-      { mutate: mutateMock, isPending: false } as unknown as ReturnType<typeof useRenameProject>
+    vi.mocked(useRenameSolution).mockReturnValue(
+      { mutate: mutateMock, isPending: false } as unknown as ReturnType<typeof useRenameSolution>
     );
-    const mockProject = { id: 10, name: "MyDB", fm_version: "19", file_path: "", imported_at: "" };
-    vi.mocked(useAppStore).mockReturnValue({
-      selectedSolution: mockSolutions[0],
-      selectedProject: null,
-      selectSolution: mockSelectSolution,
-      selectProject: mockSelectProject,
-      selectElement: mockSelectElement,
-      setRightPanel: mockSetRightPanel,
-      renameProjectInStore: mockRenameProjectInStore,
-    } as unknown as ReturnType<typeof useAppStore>);
     vi.mocked(useSolutions).mockReturnValue(
       { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
     );
-    vi.mocked(useSolutionProjects).mockReturnValue(
-      { data: [mockProject], isLoading: false } as unknown as ReturnType<typeof useSolutionProjects>
-    );
     render(<SolutionList />);
-    fireEvent.click(screen.getByRole("button", { name: "名前を変更" }));
+    const renameButtons = screen.getAllByRole("button", { name: "名前を変更" });
+    fireEvent.click(renameButtons[0]);
     const input = screen.getByRole("textbox");
     fireEvent.change(input, { target: { value: "新しい名前" } });
     fireEvent.keyDown(input, { key: "Enter" });
     expect(mutateMock).toHaveBeenCalledWith(
-      { projectId: 10, newName: "新しい名前" },
+      { solutionId: 1, newName: "新しい名前" },
       expect.objectContaining({ onSuccess: expect.any(Function) })
     );
   });

--- a/src/__tests__/SolutionList.test.tsx
+++ b/src/__tests__/SolutionList.test.tsx
@@ -8,6 +8,7 @@ vi.mock("../hooks/solutions", () => ({
   useDeleteSolution: vi.fn(),
   useSolutionProjects: vi.fn(),
   useDeleteProject: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useRenameProject: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("../stores/appStore", () => ({
@@ -19,7 +20,7 @@ vi.mock("../components/navigation/CategoryTree", () => ({
   CategoryTree: () => null,
 }));
 
-import { useSolutions, useDeleteSolution, useSolutionProjects, useDeleteProject } from "../hooks/solutions";
+import { useSolutions, useDeleteSolution, useSolutionProjects, useDeleteProject, useRenameProject } from "../hooks/solutions";
 import { useAppStore } from "../stores/appStore";
 
 const mockSolutions: SolutionRow[] = [
@@ -31,6 +32,7 @@ const mockSelectSolution = vi.fn();
 const mockSelectProject = vi.fn();
 const mockSelectElement = vi.fn();
 const mockSetRightPanel = vi.fn();
+const mockRenameProjectInStore = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -41,6 +43,7 @@ beforeEach(() => {
     selectProject: mockSelectProject,
     selectElement: mockSelectElement,
     setRightPanel: mockSetRightPanel,
+    renameProjectInStore: mockRenameProjectInStore,
   } as unknown as ReturnType<typeof useAppStore>);
   vi.mocked(useDeleteSolution).mockReturnValue(
     { mutate: vi.fn(), isPending: false } as unknown as ReturnType<typeof useDeleteSolution>
@@ -248,6 +251,7 @@ describe("SolutionList", () => {
       selectProject: mockSelectProject,
       selectElement: mockSelectElement,
       setRightPanel: mockSetRightPanel,
+      renameProjectInStore: mockRenameProjectInStore,
     } as unknown as ReturnType<typeof useAppStore>);
     vi.mocked(useSolutions).mockReturnValue(
       { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
@@ -260,5 +264,84 @@ describe("SolutionList", () => {
     const projectRow = screen.getByText(/MyDB/).closest("div[class*='cursor-pointer']")!;
     fireEvent.click(projectRow);
     expect(mockSelectProject).toHaveBeenCalledWith(mockProject);
+  });
+
+  it("rename_button_shows_inline_input", () => {
+    const mockProject = { id: 10, name: "MyDB", fm_version: "19", file_path: "", imported_at: "" };
+    vi.mocked(useAppStore).mockReturnValue({
+      selectedSolution: mockSolutions[0],
+      selectedProject: null,
+      selectSolution: mockSelectSolution,
+      selectProject: mockSelectProject,
+      selectElement: mockSelectElement,
+      setRightPanel: mockSetRightPanel,
+      renameProjectInStore: mockRenameProjectInStore,
+    } as unknown as ReturnType<typeof useAppStore>);
+    vi.mocked(useSolutions).mockReturnValue(
+      { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
+    );
+    vi.mocked(useSolutionProjects).mockReturnValue(
+      { data: [mockProject], isLoading: false } as unknown as ReturnType<typeof useSolutionProjects>
+    );
+    render(<SolutionList />);
+    fireEvent.click(screen.getByRole("button", { name: "名前を変更" }));
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("MyDB")).toBeInTheDocument();
+  });
+
+  it("rename_escape_cancels_edit", () => {
+    const mockProject = { id: 10, name: "MyDB", fm_version: "19", file_path: "", imported_at: "" };
+    vi.mocked(useAppStore).mockReturnValue({
+      selectedSolution: mockSolutions[0],
+      selectedProject: null,
+      selectSolution: mockSelectSolution,
+      selectProject: mockSelectProject,
+      selectElement: mockSelectElement,
+      setRightPanel: mockSetRightPanel,
+      renameProjectInStore: mockRenameProjectInStore,
+    } as unknown as ReturnType<typeof useAppStore>);
+    vi.mocked(useSolutions).mockReturnValue(
+      { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
+    );
+    vi.mocked(useSolutionProjects).mockReturnValue(
+      { data: [mockProject], isLoading: false } as unknown as ReturnType<typeof useSolutionProjects>
+    );
+    render(<SolutionList />);
+    fireEvent.click(screen.getByRole("button", { name: "名前を変更" }));
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("rename_enter_calls_mutation_with_new_name", () => {
+    const mutateMock = vi.fn();
+    vi.mocked(useRenameProject).mockReturnValue(
+      { mutate: mutateMock, isPending: false } as unknown as ReturnType<typeof useRenameProject>
+    );
+    const mockProject = { id: 10, name: "MyDB", fm_version: "19", file_path: "", imported_at: "" };
+    vi.mocked(useAppStore).mockReturnValue({
+      selectedSolution: mockSolutions[0],
+      selectedProject: null,
+      selectSolution: mockSelectSolution,
+      selectProject: mockSelectProject,
+      selectElement: mockSelectElement,
+      setRightPanel: mockSetRightPanel,
+      renameProjectInStore: mockRenameProjectInStore,
+    } as unknown as ReturnType<typeof useAppStore>);
+    vi.mocked(useSolutions).mockReturnValue(
+      { data: mockSolutions, isLoading: false, isError: false } as unknown as ReturnType<typeof useSolutions>
+    );
+    vi.mocked(useSolutionProjects).mockReturnValue(
+      { data: [mockProject], isLoading: false } as unknown as ReturnType<typeof useSolutionProjects>
+    );
+    render(<SolutionList />);
+    fireEvent.click(screen.getByRole("button", { name: "名前を変更" }));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "新しい名前" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mutateMock).toHaveBeenCalledWith(
+      { projectId: 10, newName: "新しい名前" },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
   });
 });

--- a/src/components/SolutionList.tsx
+++ b/src/components/SolutionList.tsx
@@ -41,7 +41,7 @@ function ProjectItems({ solution }: { solution: SolutionRow }) {
                 <Spinner className="w-3.5 h-3.5 ml-1" />
               ) : (
                 <button
-                  className="ml-1 text-gray-300 hover:text-red-500 flex-shrink-0 text-lg leading-none"
+                  className="ml-1 text-gray-400 hover:text-red-500 flex-shrink-0 text-lg leading-none"
                   onClick={(e) => {
                     e.stopPropagation();
                     setConfirmingProjectId(project.id);
@@ -129,7 +129,7 @@ export function SolutionList() {
         <li key={solution.id} className={isDeleting ? "opacity-50 pointer-events-none" : ""}>
           {/* ソリューション行 */}
           <div
-            className={`group flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-gray-50 ${
+            className={`group flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-gray-100 ${
               selectedSolution?.id === solution.id ? "bg-gray-100" : ""
             }`}
             onClick={() => {

--- a/src/components/SolutionList.tsx
+++ b/src/components/SolutionList.tsx
@@ -102,6 +102,7 @@ export function SolutionList() {
   const [deletingSolutionId, setDeletingSolutionId] = useState<number | null>(null);
   const [renamingSolutionId, setRenamingSolutionId] = useState<number | null>(null);
   const [renameValue, setRenameValue] = useState("");
+  // 同時に編集できるのは 1 件のみなので、Enter/blur の二重 mutation 防止に 1 つの ref で十分
   const resolvedRef = useRef(false);
 
   if (isLoading) {

--- a/src/components/SolutionList.tsx
+++ b/src/components/SolutionList.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useSolutions, useDeleteSolution, useDeleteProject, useSolutionProjects, useRenameProject } from "../hooks/solutions";
+import { useSolutions, useDeleteSolution, useDeleteProject, useSolutionProjects, useRenameSolution } from "../hooks/solutions";
 import { useAppStore } from "../stores/appStore";
 import { CategoryTree } from "./navigation/CategoryTree";
 import { Spinner } from "./Spinner";
@@ -7,13 +7,10 @@ import type { SolutionRow } from "../types/ddr";
 
 function ProjectItems({ solution }: { solution: SolutionRow }) {
   const { data: projects, isLoading } = useSolutionProjects(solution.id);
-  const { selectedProject, selectProject, setRightPanel, purgeProjectFromHistory, renameProjectInStore } = useAppStore();
+  const { selectedProject, selectProject, setRightPanel, purgeProjectFromHistory } = useAppStore();
   const { mutate: deleteProject, isPending: isDeletingProject } = useDeleteProject();
-  const { mutate: renameProject } = useRenameProject();
   const [confirmingProjectId, setConfirmingProjectId] = useState<number | null>(null);
   const [deletingProjectId, setDeletingProjectId] = useState<number | null>(null);
-  const [renamingProjectId, setRenamingProjectId] = useState<number | null>(null);
-  const [renameValue, setRenameValue] = useState("");
 
   if (isLoading) {
     return <li className="flex items-center gap-1.5 px-6 py-1 text-xs text-gray-400"><Spinner className="w-3 h-3" />読み込み中...</li>;
@@ -31,65 +28,28 @@ function ProjectItems({ solution }: { solution: SolutionRow }) {
         return (
           <li key={project.id} className={isDeleting ? "opacity-50 pointer-events-none" : ""}>
             <div
-              className={`group flex items-center justify-between px-6 py-1.5 cursor-pointer text-sm hover:bg-blue-50 ${
+              className={`flex items-center justify-between px-6 py-1.5 cursor-pointer text-sm hover:bg-blue-50 ${
                 isSelected ? "bg-blue-100 text-blue-700 font-medium" : "text-gray-700"
               }`}
-              onClick={() => { if (renamingProjectId !== project.id) { setRightPanel(null); selectProject(project); } }}
+              onClick={() => { setRightPanel(null); selectProject(project); }}
             >
-              {renamingProjectId === project.id ? (
-                <input
-                  className="flex-1 min-w-0 px-1 text-sm border border-blue-400 rounded outline-none"
-                  value={renameValue}
-                  autoFocus
-                  onChange={(e) => setRenameValue(e.target.value)}
-                  onClick={(e) => e.stopPropagation()}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      const trimmed = renameValue.trim();
-                      if (trimmed && trimmed !== project.name) {
-                        renameProject(
-                          { projectId: project.id, newName: trimmed },
-                          { onSuccess: () => renameProjectInStore(project.id, trimmed) }
-                        );
-                      }
-                      setRenamingProjectId(null);
-                    } else if (e.key === "Escape") {
-                      setRenamingProjectId(null);
-                    }
-                  }}
-                />
-              ) : (
-                <span className="truncate" title={project.name}>
-                  📄 {project.name}
-                  <span className="ml-1 text-xs text-gray-400">{project.fm_version}</span>
-                </span>
-              )}
+              <span className="truncate" title={project.name}>
+                📄 {project.name}
+                <span className="ml-1 text-xs text-gray-400">{project.fm_version}</span>
+              </span>
               {isDeleting ? (
                 <Spinner className="w-3.5 h-3.5 ml-1" />
               ) : (
-                <span className="flex items-center gap-0.5 flex-shrink-0">
-                  <button
-                    className="text-gray-300 hover:text-blue-500 opacity-0 group-hover:opacity-100 text-sm leading-none"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setRenamingProjectId(project.id);
-                      setRenameValue(project.name);
-                    }}
-                    aria-label="名前を変更"
-                  >
-                    ✏
-                  </button>
-                  <button
-                    className="ml-0.5 text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 text-lg leading-none"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setConfirmingProjectId(project.id);
-                    }}
-                    aria-label="削除"
-                  >
-                    ×
-                  </button>
-                </span>
+                <button
+                  className="ml-1 text-gray-300 hover:text-red-500 flex-shrink-0 text-lg leading-none"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setConfirmingProjectId(project.id);
+                  }}
+                  aria-label="削除"
+                >
+                  ×
+                </button>
               )}
             </div>
             {confirmingProjectId === project.id && (
@@ -136,9 +96,12 @@ function ProjectItems({ solution }: { solution: SolutionRow }) {
 export function SolutionList() {
   const { data: solutions, isLoading, isError } = useSolutions();
   const { mutate: deleteSolution, isPending: isDeletingSolution } = useDeleteSolution();
-  const { selectedSolution, selectSolution, selectProject, selectElement, setRightPanel } = useAppStore();
+  const { mutate: renameSolution } = useRenameSolution();
+  const { selectedSolution, selectSolution, selectProject, selectElement, setRightPanel, renameSolutionInStore } = useAppStore();
   const [confirmingSolutionId, setConfirmingSolutionId] = useState<number | null>(null);
   const [deletingSolutionId, setDeletingSolutionId] = useState<number | null>(null);
+  const [renamingSolutionId, setRenamingSolutionId] = useState<number | null>(null);
+  const [renameValue, setRenameValue] = useState("");
 
   if (isLoading) {
     return <div className="flex items-center gap-2 p-4 text-gray-500 text-sm"><Spinner className="w-4 h-4" />読み込み中...</div>;
@@ -160,39 +123,83 @@ export function SolutionList() {
     <ul className="divide-y divide-gray-100">
       {solutions.map((solution) => {
         const isDeleting = deletingSolutionId === solution.id && isDeletingSolution;
+        const isRenaming = renamingSolutionId === solution.id;
         return (
         <li key={solution.id} className={isDeleting ? "opacity-50 pointer-events-none" : ""}>
           {/* ソリューション行 */}
           <div
-            className={`flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-gray-50 ${
+            className={`group flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-gray-50 ${
               selectedSolution?.id === solution.id ? "bg-gray-100" : ""
             }`}
             onClick={() => {
-              setRightPanel(null);
-              selectSolution(solution);
+              if (!isRenaming) {
+                setRightPanel(null);
+                selectSolution(solution);
+              }
             }}
           >
             <div className="flex-1 min-w-0">
-              <div className="truncate text-sm font-medium text-gray-900" title={solution.name}>
-                🗂 {solution.name}
-              </div>
-              <div className="text-xs text-gray-400">
-                {solution.imported_at.slice(0, 16)}
-              </div>
+              {isRenaming ? (
+                <input
+                  className="w-full px-1 text-sm font-medium border border-blue-400 rounded outline-none"
+                  value={renameValue}
+                  autoFocus
+                  onChange={(e) => setRenameValue(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      const trimmed = renameValue.trim();
+                      if (trimmed && trimmed !== solution.name) {
+                        renameSolution(
+                          { solutionId: solution.id, newName: trimmed },
+                          { onSuccess: () => renameSolutionInStore(solution.id, trimmed) }
+                        );
+                      }
+                      setRenamingSolutionId(null);
+                    } else if (e.key === "Escape") {
+                      setRenamingSolutionId(null);
+                    }
+                  }}
+                />
+              ) : (
+                <>
+                  <div className="truncate text-sm font-medium text-gray-900" title={solution.name}>
+                    🗂 {solution.name}
+                  </div>
+                  <div className="text-xs text-gray-400">
+                    {solution.imported_at.slice(0, 16)}
+                  </div>
+                </>
+              )}
             </div>
             {isDeleting ? (
               <Spinner className="w-4 h-4 ml-2" />
             ) : (
-              <button
-                className="ml-2 text-gray-300 hover:text-red-500 flex-shrink-0 text-lg leading-none"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setConfirmingSolutionId(solution.id);
-                }}
-                aria-label="削除"
-              >
-                ×
-              </button>
+              <span className="flex items-center gap-0.5 flex-shrink-0 ml-2">
+                {!confirmingSolutionId && (
+                  <button
+                    className="text-gray-300 hover:text-blue-500 opacity-0 group-hover:opacity-100 text-sm leading-none"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setRenamingSolutionId(solution.id);
+                      setRenameValue(solution.name);
+                    }}
+                    aria-label="名前を変更"
+                  >
+                    ✏
+                  </button>
+                )}
+                <button
+                  className="ml-0.5 text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 text-lg leading-none"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setConfirmingSolutionId(solution.id);
+                  }}
+                  aria-label="削除"
+                >
+                  ×
+                </button>
+              </span>
             )}
           </div>
           {confirmingSolutionId === solution.id && (

--- a/src/components/SolutionList.tsx
+++ b/src/components/SolutionList.tsx
@@ -196,7 +196,7 @@ export function SolutionList() {
               <span className="flex items-center gap-0.5 flex-shrink-0 ml-2">
                 {!confirmingSolutionId && !isRenaming && (
                   <button
-                    className="text-gray-300 hover:text-blue-500 opacity-0 group-hover:opacity-100 text-sm leading-none"
+                    className="text-gray-400 hover:text-blue-500 opacity-0 group-hover:opacity-100 transition-opacity duration-100 text-base leading-none"
                     onClick={(e) => {
                       e.stopPropagation();
                       resolvedRef.current = false;
@@ -209,7 +209,7 @@ export function SolutionList() {
                   </button>
                 )}
                 <button
-                  className="ml-0.5 text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 text-lg leading-none"
+                  className="ml-0.5 text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity duration-100 text-lg leading-none"
                   onClick={(e) => {
                     e.stopPropagation();
                     setConfirmingSolutionId(solution.id);

--- a/src/components/SolutionList.tsx
+++ b/src/components/SolutionList.tsx
@@ -193,10 +193,10 @@ export function SolutionList() {
             {isDeleting ? (
               <Spinner className="w-4 h-4 ml-2" />
             ) : (
-              <span className="flex items-center gap-0.5 flex-shrink-0 ml-2">
+              <span className="flex items-center gap-2 flex-shrink-0 ml-2">
                 {!confirmingSolutionId && !isRenaming && (
                   <button
-                    className="text-gray-400 hover:text-blue-500 opacity-0 group-hover:opacity-100 transition-opacity duration-100 text-base leading-none"
+                    className="text-gray-400 hover:text-blue-500 opacity-0 group-hover:opacity-100 transition-opacity duration-100 text-lg leading-none"
                     onClick={(e) => {
                       e.stopPropagation();
                       resolvedRef.current = false;
@@ -209,7 +209,7 @@ export function SolutionList() {
                   </button>
                 )}
                 <button
-                  className="ml-0.5 text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity duration-100 text-lg leading-none"
+                  className="text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity duration-100 text-lg leading-none"
                   onClick={(e) => {
                     e.stopPropagation();
                     setConfirmingSolutionId(solution.id);

--- a/src/components/SolutionList.tsx
+++ b/src/components/SolutionList.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useSolutions, useDeleteSolution, useDeleteProject, useSolutionProjects } from "../hooks/solutions";
+import { useSolutions, useDeleteSolution, useDeleteProject, useSolutionProjects, useRenameProject } from "../hooks/solutions";
 import { useAppStore } from "../stores/appStore";
 import { CategoryTree } from "./navigation/CategoryTree";
 import { Spinner } from "./Spinner";
@@ -7,10 +7,13 @@ import type { SolutionRow } from "../types/ddr";
 
 function ProjectItems({ solution }: { solution: SolutionRow }) {
   const { data: projects, isLoading } = useSolutionProjects(solution.id);
-  const { selectedProject, selectProject, setRightPanel, purgeProjectFromHistory } = useAppStore();
+  const { selectedProject, selectProject, setRightPanel, purgeProjectFromHistory, renameProjectInStore } = useAppStore();
   const { mutate: deleteProject, isPending: isDeletingProject } = useDeleteProject();
+  const { mutate: renameProject } = useRenameProject();
   const [confirmingProjectId, setConfirmingProjectId] = useState<number | null>(null);
   const [deletingProjectId, setDeletingProjectId] = useState<number | null>(null);
+  const [renamingProjectId, setRenamingProjectId] = useState<number | null>(null);
+  const [renameValue, setRenameValue] = useState("");
 
   if (isLoading) {
     return <li className="flex items-center gap-1.5 px-6 py-1 text-xs text-gray-400"><Spinner className="w-3 h-3" />読み込み中...</li>;
@@ -28,28 +31,65 @@ function ProjectItems({ solution }: { solution: SolutionRow }) {
         return (
           <li key={project.id} className={isDeleting ? "opacity-50 pointer-events-none" : ""}>
             <div
-              className={`flex items-center justify-between px-6 py-1.5 cursor-pointer text-sm hover:bg-blue-50 ${
+              className={`group flex items-center justify-between px-6 py-1.5 cursor-pointer text-sm hover:bg-blue-50 ${
                 isSelected ? "bg-blue-100 text-blue-700 font-medium" : "text-gray-700"
               }`}
-              onClick={() => { setRightPanel(null); selectProject(project); }}
+              onClick={() => { if (renamingProjectId !== project.id) { setRightPanel(null); selectProject(project); } }}
             >
-              <span className="truncate" title={project.name}>
-                📄 {project.name}
-                <span className="ml-1 text-xs text-gray-400">{project.fm_version}</span>
-              </span>
+              {renamingProjectId === project.id ? (
+                <input
+                  className="flex-1 min-w-0 px-1 text-sm border border-blue-400 rounded outline-none"
+                  value={renameValue}
+                  autoFocus
+                  onChange={(e) => setRenameValue(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      const trimmed = renameValue.trim();
+                      if (trimmed && trimmed !== project.name) {
+                        renameProject(
+                          { projectId: project.id, newName: trimmed },
+                          { onSuccess: () => renameProjectInStore(project.id, trimmed) }
+                        );
+                      }
+                      setRenamingProjectId(null);
+                    } else if (e.key === "Escape") {
+                      setRenamingProjectId(null);
+                    }
+                  }}
+                />
+              ) : (
+                <span className="truncate" title={project.name}>
+                  📄 {project.name}
+                  <span className="ml-1 text-xs text-gray-400">{project.fm_version}</span>
+                </span>
+              )}
               {isDeleting ? (
                 <Spinner className="w-3.5 h-3.5 ml-1" />
               ) : (
-                <button
-                  className="ml-1 text-gray-300 hover:text-red-500 flex-shrink-0 text-lg leading-none"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setConfirmingProjectId(project.id);
-                  }}
-                  aria-label="削除"
-                >
-                  ×
-                </button>
+                <span className="flex items-center gap-0.5 flex-shrink-0">
+                  <button
+                    className="text-gray-300 hover:text-blue-500 opacity-0 group-hover:opacity-100 text-sm leading-none"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setRenamingProjectId(project.id);
+                      setRenameValue(project.name);
+                    }}
+                    aria-label="名前を変更"
+                  >
+                    ✏
+                  </button>
+                  <button
+                    className="ml-0.5 text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 text-lg leading-none"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setConfirmingProjectId(project.id);
+                    }}
+                    aria-label="削除"
+                  >
+                    ×
+                  </button>
+                </span>
               )}
             </div>
             {confirmingProjectId === project.id && (

--- a/src/components/SolutionList.tsx
+++ b/src/components/SolutionList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useSolutions, useDeleteSolution, useDeleteProject, useSolutionProjects, useRenameSolution } from "../hooks/solutions";
 import { useAppStore } from "../stores/appStore";
 import { CategoryTree } from "./navigation/CategoryTree";
@@ -102,6 +102,7 @@ export function SolutionList() {
   const [deletingSolutionId, setDeletingSolutionId] = useState<number | null>(null);
   const [renamingSolutionId, setRenamingSolutionId] = useState<number | null>(null);
   const [renameValue, setRenameValue] = useState("");
+  const resolvedRef = useRef(false);
 
   if (isLoading) {
     return <div className="flex items-center gap-2 p-4 text-gray-500 text-sm"><Spinner className="w-4 h-4" />読み込み中...</div>;
@@ -148,6 +149,25 @@ export function SolutionList() {
                   onClick={(e) => e.stopPropagation()}
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
+                      if (!resolvedRef.current) {
+                        resolvedRef.current = true;
+                        const trimmed = renameValue.trim();
+                        if (trimmed && trimmed !== solution.name) {
+                          renameSolution(
+                            { solutionId: solution.id, newName: trimmed },
+                            { onSuccess: () => renameSolutionInStore(solution.id, trimmed) }
+                          );
+                        }
+                      }
+                      setRenamingSolutionId(null);
+                    } else if (e.key === "Escape") {
+                      resolvedRef.current = true;
+                      setRenamingSolutionId(null);
+                    }
+                  }}
+                  onBlur={() => {
+                    if (!resolvedRef.current) {
+                      resolvedRef.current = true;
                       const trimmed = renameValue.trim();
                       if (trimmed && trimmed !== solution.name) {
                         renameSolution(
@@ -155,10 +175,8 @@ export function SolutionList() {
                           { onSuccess: () => renameSolutionInStore(solution.id, trimmed) }
                         );
                       }
-                      setRenamingSolutionId(null);
-                    } else if (e.key === "Escape") {
-                      setRenamingSolutionId(null);
                     }
+                    setRenamingSolutionId(null);
                   }}
                 />
               ) : (
@@ -176,11 +194,12 @@ export function SolutionList() {
               <Spinner className="w-4 h-4 ml-2" />
             ) : (
               <span className="flex items-center gap-0.5 flex-shrink-0 ml-2">
-                {!confirmingSolutionId && (
+                {!confirmingSolutionId && !isRenaming && (
                   <button
                     className="text-gray-300 hover:text-blue-500 opacity-0 group-hover:opacity-100 text-sm leading-none"
                     onClick={(e) => {
                       e.stopPropagation();
+                      resolvedRef.current = false;
                       setRenamingSolutionId(solution.id);
                       setRenameValue(solution.name);
                     }}

--- a/src/hooks/solutions.ts
+++ b/src/hooks/solutions.ts
@@ -87,12 +87,12 @@ export function useSolutionProjectSummaries(solutionId: number | null) {
   });
 }
 
-// プロジェクト名変更
-export function useRenameProject() {
+// ソリューション名変更
+export function useRenameSolution() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ projectId, newName }: { projectId: number; newName: string }) =>
-      invoke<void>("rename_project", { projectId, newName }),
+    mutationFn: ({ solutionId, newName }: { solutionId: number; newName: string }) =>
+      invoke<void>("rename_solution", { solutionId, newName }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["solutions"] });
     },

--- a/src/hooks/solutions.ts
+++ b/src/hooks/solutions.ts
@@ -87,6 +87,18 @@ export function useSolutionProjectSummaries(solutionId: number | null) {
   });
 }
 
+// プロジェクト名変更
+export function useRenameProject() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ projectId, newName }: { projectId: number; newName: string }) =>
+      invoke<void>("rename_project", { projectId, newName }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["solutions"] });
+    },
+  });
+}
+
 // 全プロジェクト一覧（プロジェクト選択ドロップダウン用）
 export function useAllProjects(options?: { enabled?: boolean }) {
   return useQuery({

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -201,6 +201,7 @@ interface AppState {
   navigateForward: () => void;
   purgeProjectFromHistory: (projectId: number) => void;
   navigateToProject: (project: ProjectRow) => void;
+  renameProjectInStore: (projectId: number, newName: string) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -390,6 +391,13 @@ export const useAppStore = create<AppState>((set) => ({
         : filtered.indexOf(currentEntry);
       return { navHistory: filtered, navIndex: Math.max(-1, newIndex) };
     }),
+  renameProjectInStore: (projectId, newName) =>
+    set((state) => ({
+      selectedProject:
+        state.selectedProject?.id === projectId
+          ? { ...state.selectedProject, name: newName }
+          : state.selectedProject,
+    })),
   navigateToProject: (project: ProjectRow) =>
     set((state) => {
       // 現在の要素を履歴に残しつつ、プロジェクト dashboard エントリを追加する

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -201,7 +201,7 @@ interface AppState {
   navigateForward: () => void;
   purgeProjectFromHistory: (projectId: number) => void;
   navigateToProject: (project: ProjectRow) => void;
-  renameProjectInStore: (projectId: number, newName: string) => void;
+  renameSolutionInStore: (solutionId: number, newName: string) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -391,12 +391,12 @@ export const useAppStore = create<AppState>((set) => ({
         : filtered.indexOf(currentEntry);
       return { navHistory: filtered, navIndex: Math.max(-1, newIndex) };
     }),
-  renameProjectInStore: (projectId, newName) =>
+  renameSolutionInStore: (solutionId, newName) =>
     set((state) => ({
-      selectedProject:
-        state.selectedProject?.id === projectId
-          ? { ...state.selectedProject, name: newName }
-          : state.selectedProject,
+      selectedSolution:
+        state.selectedSolution?.id === solutionId
+          ? { ...state.selectedSolution, name: newName }
+          : state.selectedSolution,
     })),
   navigateToProject: (project: ProjectRow) =>
     set((state) => {


### PR DESCRIPTION
## Summary

- ホバー時に表示される鉛筆ボタン（✏）をクリックするとソリューション名がインライン `<input>` に切り替わる
- Enter で確定・Escape でキャンセル・フォーカス外し（blur）でも確定
- 空文字・変更なしは送信しない。Enter/blur の二重送信は `resolvedRef` で防止
- 既存の × 削除ボタンと同じホバー表示パターンを踏襲（編集中は鉛筆ボタン非表示）
- 選択中ソリューションが対象の場合、ストアの `selectedSolution.name` もその場で更新（`renameSolutionInStore`）

Closes #52

## Changes

### Rust
- `db/repository/solution.rs`: `update_solution_name` 関数を追加
- `db/repository/mod.rs`: `update_solution_name` を re-export
- `commands/analysis.rs`: `rename_solution` IPC コマンドを追加
- `lib.rs`: `invoke_handler` に `rename_solution` を登録

### フロントエンド
- `hooks/solutions.ts`: `useRenameSolution` mutation フックを追加
- `stores/appStore.ts`: `renameSolutionInStore` アクションを追加
- `components/SolutionList.tsx`: ソリューション行（🗂）に鉛筆ボタン＋インライン input を追加

### UI 修正（同ブランチで対応）
- onBlur 未実装バグ修正（フォーカス外しで編集状態が残る問題）
- 編集中に鉛筆ボタンを非表示にし、再クリックによる入力値リセットを防止
- 鉛筆・× ボタンのサイズ・色・間隔を調整（`text-lg`、`text-gray-400`、`gap-2`）
- SolutionList 行ホバー・ProjectItems の × ボタン色をアプリ全体のパターンに統一

### テスト
- `solution.rs` `#[cfg(test)]`: `update_solution_name_changes_name` / `update_solution_name_not_found_returns_err`
- `SolutionList.test.tsx`: 8 ケース追加（編集開始・Escape・Enter・blur 確定・変更なし blur・鉛筆非表示・Escape で mutation なし）

## Test plan

- [x] Rust: `cargo test --lib` passed
- [x] Frontend: `npm run test` 379 passed
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `tsc --noEmit`

Generated with [Claude Code](https://claude.com/claude-code)