### PR TITLE
fix: グローバルデザイン整合性の修正（Issue #62）

### DIFF
--- a/src/components/ReportCard.tsx
+++ b/src/components/ReportCard.tsx
@@ -40,7 +40,7 @@ export function ReportCard({ projectId }: Props) {
   }
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
+    <div className="bg-white rounded-xl border border-gray-200 p-4">
       <div className="flex items-center justify-between mb-3">
         <h3 className="font-semibold text-gray-800">レポートカード</h3>
         {isHealthy ? (

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -41,7 +41,7 @@ export function SearchBar() {
           value={localValue}
           onChange={(e) => setLocalValue(e.target.value)}
           placeholder="スクリプト、フィールド、レイアウトを検索..."
-          className="w-full pl-3 pr-8 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:border-blue-400"
+          className="w-full pl-3 pr-8 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-blue-400"
         />
         {localValue && (
           <button

--- a/src/components/navigation/CategoryTree.tsx
+++ b/src/components/navigation/CategoryTree.tsx
@@ -58,7 +58,7 @@ const ItemRow = forwardRef<HTMLButtonElement, ItemRowProps>(
     <button
       ref={ref}
       className={`w-full text-left px-12 py-1.5 text-sm truncate hover:bg-blue-50 transition-colors ${
-        isSelected ? "bg-blue-100 text-blue-800 font-medium" : "text-gray-600"
+        isSelected ? "bg-blue-100 text-blue-700 font-medium" : "text-gray-600"
       }`}
       onClick={onClick}
       title={name}
@@ -161,7 +161,7 @@ export function CategoryTree({ projectId }: Props) {
       <button
         className={`w-full flex items-center justify-between px-9 py-1.5 text-sm font-semibold transition-colors ${
           isSelected({ kind: "all_fields", projectId })
-            ? "bg-blue-100 text-blue-800"
+            ? "bg-blue-100 text-blue-700"
             : "text-gray-700 hover:bg-gray-100"
         }`}
         onClick={() => {
@@ -204,7 +204,7 @@ export function CategoryTree({ projectId }: Props) {
       <button
         className={`w-full flex items-center justify-between px-9 py-1.5 text-sm font-semibold transition-colors ${
           isSelected({ kind: "all_table_occurrences", projectId })
-            ? "bg-blue-100 text-blue-800"
+            ? "bg-blue-100 text-blue-700"
             : "text-gray-700 hover:bg-gray-100"
         }`}
         onClick={() => {
@@ -222,7 +222,7 @@ export function CategoryTree({ projectId }: Props) {
       <button
         className={`w-full flex items-center justify-between px-9 py-1.5 text-sm font-semibold transition-colors ${
           isSelected({ kind: "all_relationships", projectId })
-            ? "bg-blue-100 text-blue-800"
+            ? "bg-blue-100 text-blue-700"
             : "text-gray-700 hover:bg-gray-100"
         }`}
         onClick={() => {
@@ -340,7 +340,7 @@ export function CategoryTree({ projectId }: Props) {
       <button
         className={`w-full flex items-center gap-1.5 px-9 py-1.5 text-sm font-semibold transition-colors ${
           isSelected({ kind: "relationship_graph", projectId })
-            ? "bg-blue-100 text-blue-800"
+            ? "bg-blue-100 text-blue-700"
             : "text-gray-700 hover:bg-gray-100"
         }`}
         onClick={() => {
@@ -356,7 +356,7 @@ export function CategoryTree({ projectId }: Props) {
       <button
         className={`w-full flex items-center justify-between px-9 py-1.5 text-sm font-semibold transition-colors ${
           isSelected({ kind: "all_external_data_sources", projectId })
-            ? "bg-blue-100 text-blue-800"
+            ? "bg-blue-100 text-blue-700"
             : "text-gray-700 hover:bg-gray-100"
         }`}
         onClick={() => {
@@ -377,7 +377,7 @@ export function CategoryTree({ projectId }: Props) {
       <button
         className={`w-full flex items-center gap-1.5 px-9 py-1.5 text-sm font-semibold transition-colors ${
           isSelected({ kind: "security", projectId })
-            ? "bg-blue-100 text-blue-800"
+            ? "bg-blue-100 text-blue-700"
             : "text-gray-700 hover:bg-gray-100"
         }`}
         onClick={() => {


### PR DESCRIPTION
## Summary

- CategoryTree の選択テキスト色を `text-blue-700` に統一（他コンポーネントと合わせる）
- ReportCard のカード角丸を `rounded-xl` に統一（`CARD` トークン定義に合わせる）
- SearchBar のフォーカス表示を `focus:ring-1 focus:ring-blue-400` に統一（AllTablesPanel・SELECT_INPUT トークンと合わせる）

Closes #62

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `CategoryTree.tsx` | `text-blue-800` × 7 → `text-blue-700` |
| `ReportCard.tsx` | `rounded-lg` → `rounded-xl`（カードコンテナ） |
| `SearchBar.tsx` | `focus:border-blue-400` → `focus:ring-1 focus:ring-blue-400` |

すべて Tailwind クラスの値変更のみ。テスト追加なし。

## Test plan

- [x] `npm run test` 379 passed
- [x] `tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)