### PR TITLE
refactor: デザイントークン整理（リリース前クリーンアップ）

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -113,7 +113,7 @@ filemaker-ddr-viewer/
 | `detail/field/FieldBasicProperties.tsx` 他 | FieldDetail のサブコンポーネント群（FieldAutoEnter / FieldCalcReferences / FieldLayoutReferences / FieldRelationshipReferences / FieldScriptReferences / FieldStorage / FieldValidationRules） |
 | `DiffView.tsx` | 差分比較ビュー |
 | `stores/appStore.ts` | グローバル状態（zustand） |
-| `hooks/` | ドメイン別 Tauri IPC フック（analysis / catalog / diff / fieldRefs / layout / script / search / security / solutions / table）。`hooks/analysis.ts` の `useSolutionBrokenRefs` はソリューション全プロジェクトの壊れた参照を `Promise.all` で集約 |
+| `hooks/` | ドメイン別 Tauri IPC フック（analysis / catalog / diff / fieldRefs / layout / script / search / security / solutions / table）。`hooks/analysis.ts` の `useSolutionBrokenRefs` はソリューション全プロジェクトの壊れた参照を `Promise.all` で集約。`useResolveElementByName` は差分ビューのナビゲーション用に要素名から ID を解決する命令型関数を返す hook |
 | `hooks/useColumnResize.ts` | テーブルのカラム幅ドラッグリサイズフック。`table-layout:fixed` + `<colgroup>` と組み合わせて使用。ドラッグ開始時に全列幅を DOM から実測して固定し、N 列を広げると N+1 列が縮む（合計幅一定）。最終列のみ単独変更 |
 | `hooks/useSearchFiltering.ts` | 検索フィルタリングロジック |
 | `styles/tokens.ts` | デザイントークン定数 |

--- a/src/__tests__/DiffCard.test.tsx
+++ b/src/__tests__/DiffCard.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { DiffCard } from "../components/DiffCard";
+import type { DiffResult } from "../types/ddr";
+import type { DiffStateData } from "../stores/appStore";
+
+vi.mock("../hooks/solutions", () => ({ useAllProjects: vi.fn() }));
+vi.mock("../hooks/diff", () => ({ useCompareSolutions: vi.fn() }));
+vi.mock("../stores/appStore", () => ({ useAppStore: vi.fn() }));
+vi.mock("../hooks/analysis", () => ({ useResolveElementByName: vi.fn() }));
+
+import { useAllProjects } from "../hooks/solutions";
+import { useCompareSolutions } from "../hooks/diff";
+import { useAppStore } from "../stores/appStore";
+import { useResolveElementByName } from "../hooks/analysis";
+
+const mockDiffResult: DiffResult = {
+  items: [
+    {
+      kind: "Added",
+      element_type: "script",
+      name: "NewScript",
+      detail: null,
+      project_id: 2,
+      compare_project_id: null,
+    },
+  ],
+  added_count: 1,
+  removed_count: 0,
+  modified_count: 0,
+};
+
+const mockSetDiffState = vi.fn();
+const mockSelectElement = vi.fn();
+const mockNavigateFromDiff = vi.fn();
+const mockResolve = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useAllProjects).mockReturnValue({
+    data: [],
+    isLoading: false,
+  } as unknown as ReturnType<typeof useAllProjects>);
+  vi.mocked(useCompareSolutions).mockReturnValue({
+    data: mockDiffResult,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useCompareSolutions>);
+  mockResolve.mockResolvedValue({ id: 1, name: "NewScript" });
+  vi.mocked(useResolveElementByName).mockReturnValue(mockResolve);
+});
+
+describe("DiffCard", () => {
+  it("resolve_element_called_when_navigable_item_clicked", async () => {
+    vi.mocked(useAppStore).mockReturnValue({
+      diffState: {
+        solA: 1,
+        solB: 2,
+        committedA: 1,
+        committedB: 2,
+        expandedTypes: ["script"],
+      } as DiffStateData,
+      setDiffState: mockSetDiffState,
+      selectElement: mockSelectElement,
+      navigateFromDiff: mockNavigateFromDiff,
+    } as unknown as ReturnType<typeof useAppStore>);
+
+    render(<DiffCard />);
+    fireEvent.click(screen.getByText("NewScript"));
+
+    await waitFor(() => {
+      expect(mockResolve).toHaveBeenCalledWith(2, "script", "NewScript");
+    });
+  });
+});

--- a/src/__tests__/DiffView.test.tsx
+++ b/src/__tests__/DiffView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { DiffView } from "../components/DiffView";
 import type { ProjectWithSolution, DiffResult } from "../types/ddr";
 
@@ -14,9 +14,14 @@ vi.mock("../stores/appStore", () => ({
   useAppStore: vi.fn(),
 }));
 
+vi.mock("../hooks/analysis", () => ({
+  useResolveElementByName: vi.fn(),
+}));
+
 import { useAllProjects } from "../hooks/solutions";
 import { useCompareSolutions } from "../hooks/diff";
 import { useAppStore } from "../stores/appStore";
+import { useResolveElementByName } from "../hooks/analysis";
 import type { DiffStateData } from "../stores/appStore";
 
 const mockProjects: ProjectWithSolution[] = [
@@ -57,9 +62,12 @@ const INITIAL_DIFF_STATE: DiffStateData = {
 const mockSetDiffState = vi.fn();
 const mockSelectElement = vi.fn();
 const mockNavigateFromDiff = vi.fn();
+const mockResolve = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockResolve.mockResolvedValue({ id: 1, name: "NewScript" });
+  vi.mocked(useResolveElementByName).mockReturnValue(mockResolve);
   vi.mocked(useAllProjects).mockReturnValue({
     data: mockProjects,
     isLoading: false,
@@ -143,5 +151,32 @@ describe("DiffView", () => {
   it("shows_placeholder_when_no_compare_committed", () => {
     render(<DiffView />);
     expect(screen.getByText(/Primary.*Target.*選択/)).toBeInTheDocument();
+  });
+
+  it("resolve_element_called_when_navigable_item_clicked", async () => {
+    vi.mocked(useAppStore).mockReturnValue({
+      diffState: {
+        solA: 1,
+        solB: 2,
+        committedA: 1,
+        committedB: 2,
+        expandedTypes: ["script"],
+      } as DiffStateData,
+      setDiffState: mockSetDiffState,
+      selectElement: mockSelectElement,
+      navigateFromDiff: mockNavigateFromDiff,
+      selectedElement: { kind: "diff" },
+    } as unknown as ReturnType<typeof useAppStore>);
+    vi.mocked(useCompareSolutions).mockReturnValue({
+      data: mockDiffResult,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useCompareSolutions>);
+
+    render(<DiffView />);
+    fireEvent.click(screen.getByText("NewScript"));
+
+    await waitFor(() => {
+      expect(mockResolve).toHaveBeenCalledWith(2, "script", "NewScript");
+    });
   });
 });

--- a/src/components/BrokenRefsList.tsx
+++ b/src/components/BrokenRefsList.tsx
@@ -1,7 +1,7 @@
 import { useBrokenRefs } from "../hooks/analysis";
 import { useAppStore } from "../stores/appStore";
 import type { BrokenRef } from "../types/ddr";
-import { BADGE_VARIANTS, LIST_ROW } from "../styles/tokens";
+import { BADGE_VARIANTS, CARD, LIST_ROW } from "../styles/tokens";
 import { Spinner } from "./Spinner";
 
 interface Props {
@@ -26,7 +26,7 @@ export function BrokenRefsList({ projectId }: Props) {
 
   if (!brokenRefs || brokenRefs.length === 0) {
     return (
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <div className={CARD}>
         <h3 className="font-semibold text-gray-800 mb-2">壊れた参照</h3>
         <div className="text-sm text-green-600">壊れた参照はありません</div>
       </div>
@@ -44,7 +44,7 @@ export function BrokenRefsList({ projectId }: Props) {
   }
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
+    <div className={CARD}>
       <h3 className="font-semibold text-gray-800 mb-3">
         壊れた参照
         <span className={`ml-2 ${BADGE_VARIANTS.red}`}>{brokenRefs.length}</span>

--- a/src/components/DiffCard.tsx
+++ b/src/components/DiffCard.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { useAllProjects } from "../hooks/solutions";
 import { useCompareSolutions } from "../hooks/diff";
 import { useAppStore } from "../stores/appStore";
+import { useResolveElementByName } from "../hooks/analysis";
 import type { DiffItem, DiffKind } from "../types/ddr";
 import { Spinner } from "./Spinner";
 
@@ -37,6 +37,7 @@ const NAVIGABLE_TYPES = new Set([
 
 export function DiffCard() {
   const { selectElement, navigateFromDiff, diffState, setDiffState } = useAppStore();
+  const resolveElement = useResolveElementByName();
   const { solA, solB, committedA, committedB, expandedTypes: expandedTypesArr } = diffState;
   const expandedTypes = useMemo(() => new Set(expandedTypesArr), [expandedTypesArr]);
 
@@ -84,12 +85,7 @@ export function DiffCard() {
     if (!item.project_id) return;
     if (!NAVIGABLE_TYPES.has(item.element_type)) return;
 
-    type ElementRef = { id: number; name: string };
-    const ref = await invoke<ElementRef | null>("resolve_element_by_name", {
-      projectId: item.project_id,
-      elementType: item.element_type,
-      name: item.name,
-    }).catch(() => null);
+    const ref = await resolveElement(item.project_id, item.element_type, item.name);
     if (!ref) return;
 
     const projectId = item.project_id;

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -1,9 +1,9 @@
 // src/components/DiffView.tsx
 import { useMemo } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { useAllProjects } from "../hooks/solutions";
 import { useCompareSolutions } from "../hooks/diff";
 import { useAppStore } from "../stores/appStore";
+import { useResolveElementByName } from "../hooks/analysis";
 import type { DiffItem, DiffKind } from "../types/ddr";
 import { DIFF_BADGE_VARIANTS, CARD, SELECT_INPUT } from "../styles/tokens";
 import { Spinner } from "./Spinner";
@@ -53,6 +53,7 @@ const TYPE_LABEL: Record<string, string> = {
 
 export function DiffView() {
   const { selectElement, navigateFromDiff, diffState, setDiffState, selectedElement } = useAppStore();
+  const resolveElement = useResolveElementByName();
   const { solA, solB, committedA, committedB, expandedTypes: expandedTypesArr } = diffState;
   const expandedTypes = useMemo(() => new Set(expandedTypesArr), [expandedTypesArr]);
 
@@ -120,12 +121,7 @@ export function DiffView() {
       return;
     }
 
-    type ElementRef = { id: number; name: string };
-    const ref = await invoke<ElementRef | null>("resolve_element_by_name", {
-      projectId,
-      elementType: item.element_type,
-      name: item.name,
-    }).catch(() => null);
+    const ref = await resolveElement(projectId, item.element_type, item.name);
     if (!ref) return;
 
     const el = { projectId, id: ref.id, name: ref.name };

--- a/src/components/OrphanScriptsList.tsx
+++ b/src/components/OrphanScriptsList.tsx
@@ -1,7 +1,7 @@
 import { useOrphanScripts } from "../hooks/analysis";
 import { useScriptList } from "../hooks/script";
 import { useAppStore } from "../stores/appStore";
-import { BADGE_VARIANTS } from "../styles/tokens";
+import { BADGE_VARIANTS, CARD } from "../styles/tokens";
 import { Spinner } from "./Spinner";
 
 interface Props {
@@ -18,7 +18,7 @@ export function OrphanScriptsList({ projectId }: Props) {
 
   if (!orphans || orphans.length === 0) {
     return (
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <div className={CARD}>
         <h3 className="font-semibold text-gray-800 mb-2">未使用スクリプト</h3>
         <div className="text-sm text-green-600">未使用スクリプトはありません</div>
       </div>
@@ -26,7 +26,7 @@ export function OrphanScriptsList({ projectId }: Props) {
   }
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
+    <div className={CARD}>
       <h3 className="font-semibold text-gray-800 mb-3">
         未使用スクリプト
         <span className={`ml-2 ${BADGE_VARIANTS.yellow}`}>{orphans.length}</span>

--- a/src/components/ProjectSummaryCard.tsx
+++ b/src/components/ProjectSummaryCard.tsx
@@ -1,6 +1,7 @@
 import { useProjectSummary } from "../hooks/solutions";
 import { useAppStore } from "../stores/appStore";
 import { Spinner } from "./Spinner";
+import { CARD } from "../styles/tokens";
 
 interface Props {
   projectId: number | null;
@@ -33,7 +34,7 @@ export function ProjectSummaryCard({ projectId }: Props) {
   ];
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
+    <div className={CARD}>
       <div className="flex items-center justify-between mb-3">
         <h2 className="font-semibold text-gray-800">{summary.project.name}</h2>
         <span className="text-xs text-gray-400 bg-gray-100 rounded px-2 py-0.5">

--- a/src/components/UnusedFieldsList.tsx
+++ b/src/components/UnusedFieldsList.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useUnusedFields } from "../hooks/analysis";
 import { useTableList } from "../hooks/table";
 import { useAppStore } from "../stores/appStore";
-import { BADGE_VARIANTS } from "../styles/tokens";
+import { BADGE_VARIANTS, CARD } from "../styles/tokens";
 import { Spinner } from "./Spinner";
 
 interface Props {
@@ -21,7 +21,7 @@ export function UnusedFieldsList({ projectId }: Props) {
 
   if (unused.length === 0) {
     return (
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <div className={CARD}>
         <h3 className="font-semibold text-gray-800 mb-2">未参照フィールド</h3>
         <div className="text-sm text-green-600">未参照フィールドはありません</div>
       </div>
@@ -45,7 +45,7 @@ export function UnusedFieldsList({ projectId }: Props) {
   }
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
+    <div className={CARD}>
       <div className="flex items-center justify-between mb-3">
         <h3 className="font-semibold text-gray-800">
           未参照フィールド

--- a/src/components/detail/AllCustomFunctionsPanel.tsx
+++ b/src/components/detail/AllCustomFunctionsPanel.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
 import { useColumnResize } from "../../hooks/useColumnResize";
+import { FILTER_INPUT, PAGINATION_BUTTON } from "../../styles/tokens";
 
 
 interface Props {
@@ -54,12 +55,12 @@ export function AllCustomFunctionsPanel({ projectId }: Props) {
             placeholder="カスタム関数名で絞り込み..."
             value={filter}
             onChange={handleFilterChange}
-            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
+            className={FILTER_INPUT}
           />
           <button
             onClick={() => setPage((p) => p - 1)}
             disabled={page === 0}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             &lt; 前
           </button>
@@ -69,7 +70,7 @@ export function AllCustomFunctionsPanel({ projectId }: Props) {
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={isLastPage}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             次 &gt;
           </button>

--- a/src/components/detail/AllExternalDataSourcesPanel.tsx
+++ b/src/components/detail/AllExternalDataSourcesPanel.tsx
@@ -3,6 +3,7 @@ import { useExternalDataSourceList } from "../../hooks/catalog";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
 import { useColumnResize } from "../../hooks/useColumnResize";
+import { FILTER_INPUT, PAGINATION_BUTTON } from "../../styles/tokens";
 
 interface Props {
   projectId: number;
@@ -60,12 +61,12 @@ export function AllExternalDataSourcesPanel({ projectId }: Props) {
             placeholder="ファイル名・パスで絞り込み..."
             value={filter}
             onChange={handleFilterChange}
-            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
+            className={FILTER_INPUT}
           />
           <button
             onClick={() => setPage((p) => p - 1)}
             disabled={page === 0}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             &lt; 前
           </button>
@@ -75,7 +76,7 @@ export function AllExternalDataSourcesPanel({ projectId }: Props) {
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={isLastPage}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             次 &gt;
           </button>

--- a/src/components/detail/AllFieldsPanel.tsx
+++ b/src/components/detail/AllFieldsPanel.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
 import { useColumnResize } from "../../hooks/useColumnResize";
+import { FILTER_INPUT, PAGINATION_BUTTON } from "../../styles/tokens";
 
 
 interface Props {
@@ -82,12 +83,12 @@ export function AllFieldsPanel({ projectId }: Props) {
             placeholder="テーブル名・フィールド名・型で絞り込み..."
             value={filter}
             onChange={handleFilterChange}
-            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
+            className={FILTER_INPUT}
           />
           <button
             onClick={() => setPage((p) => p - 1)}
             disabled={page === 0}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             &lt; 前
           </button>
@@ -97,7 +98,7 @@ export function AllFieldsPanel({ projectId }: Props) {
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={isLastPage}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             次 &gt;
           </button>

--- a/src/components/detail/AllLayoutsPanel.tsx
+++ b/src/components/detail/AllLayoutsPanel.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
 import { useColumnResize } from "../../hooks/useColumnResize";
+import { FILTER_INPUT, PAGINATION_BUTTON } from "../../styles/tokens";
 
 
 interface Props {
@@ -54,12 +55,12 @@ export function AllLayoutsPanel({ projectId }: Props) {
             placeholder="レイアウト名・テーブルオカレンス名で絞り込み..."
             value={filter}
             onChange={handleFilterChange}
-            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
+            className={FILTER_INPUT}
           />
           <button
             onClick={() => setPage((p) => p - 1)}
             disabled={page === 0}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             &lt; 前
           </button>
@@ -69,7 +70,7 @@ export function AllLayoutsPanel({ projectId }: Props) {
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={isLastPage}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             次 &gt;
           </button>

--- a/src/components/detail/AllRelationshipsPanel.tsx
+++ b/src/components/detail/AllRelationshipsPanel.tsx
@@ -4,6 +4,7 @@ import type { RelationshipRow } from "../../types/ddr";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
 import { useColumnResize } from "../../hooks/useColumnResize";
+import { FILTER_INPUT, PAGINATION_BUTTON } from "../../styles/tokens";
 
 interface Props {
   projectId: number;
@@ -70,12 +71,12 @@ export function AllRelationshipsPanel({ projectId, highlightId }: Props) {
             placeholder="テーブル名・フィールド名で絞り込み..."
             value={filter}
             onChange={handleFilterChange}
-            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
+            className={FILTER_INPUT}
           />
           <button
             onClick={() => setPage((p) => p - 1)}
             disabled={page === 0}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             &lt; 前
           </button>
@@ -85,7 +86,7 @@ export function AllRelationshipsPanel({ projectId, highlightId }: Props) {
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={isLastPage}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             次 &gt;
           </button>

--- a/src/components/detail/AllScriptsPanel.tsx
+++ b/src/components/detail/AllScriptsPanel.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
 import { useColumnResize } from "../../hooks/useColumnResize";
+import { FILTER_INPUT, PAGINATION_BUTTON } from "../../styles/tokens";
 
 
 interface Props {
@@ -50,12 +51,12 @@ export function AllScriptsPanel({ projectId }: Props) {
             placeholder="スクリプト名で絞り込み..."
             value={filter}
             onChange={handleFilterChange}
-            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
+            className={FILTER_INPUT}
           />
           <button
             onClick={() => setPage((p) => p - 1)}
             disabled={page === 0}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             &lt; 前
           </button>
@@ -65,7 +66,7 @@ export function AllScriptsPanel({ projectId }: Props) {
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={isLastPage}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             次 &gt;
           </button>

--- a/src/components/detail/AllTableOccurrencesPanel.tsx
+++ b/src/components/detail/AllTableOccurrencesPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { BADGE_VARIANTS } from "../../styles/tokens";
+import { BADGE_VARIANTS, FILTER_INPUT, PAGINATION_BUTTON } from "../../styles/tokens";
 import { Spinner } from "../Spinner";
 import { useTableOccurrenceList, useTableList } from "../../hooks/table";
 import { useLayoutList } from "../../hooks/layout";
@@ -78,12 +78,12 @@ export function AllTableOccurrencesPanel({ projectId }: Props) {
             placeholder="オカレンス名・ベーステーブル名で絞り込み..."
             value={filter}
             onChange={handleFilterChange}
-            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
+            className={FILTER_INPUT}
           />
           <button
             onClick={() => setPage((p) => p - 1)}
             disabled={page === 0}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             &lt; 前
           </button>
@@ -93,7 +93,7 @@ export function AllTableOccurrencesPanel({ projectId }: Props) {
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={isLastPage}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             次 &gt;
           </button>

--- a/src/components/detail/AllTablesPanel.tsx
+++ b/src/components/detail/AllTablesPanel.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
 import { useColumnResize } from "../../hooks/useColumnResize";
+import { FILTER_INPUT, PAGINATION_BUTTON } from "../../styles/tokens";
 
 
 interface Props {
@@ -50,12 +51,12 @@ export function AllTablesPanel({ projectId }: Props) {
             placeholder="テーブル名で絞り込み..."
             value={filter}
             onChange={handleFilterChange}
-            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
+            className={FILTER_INPUT}
           />
           <button
             onClick={() => setPage((p) => p - 1)}
             disabled={page === 0}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             &lt; 前
           </button>
@@ -65,7 +66,7 @@ export function AllTablesPanel({ projectId }: Props) {
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={isLastPage}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             次 &gt;
           </button>

--- a/src/components/detail/AllValueListsPanel.tsx
+++ b/src/components/detail/AllValueListsPanel.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "../../stores/appStore";
 import { Spinner } from "../Spinner";
 import { PAGE_SIZE } from "../../constants";
 import { useColumnResize } from "../../hooks/useColumnResize";
+import { FILTER_INPUT, PAGINATION_BUTTON } from "../../styles/tokens";
 
 
 interface Props {
@@ -54,12 +55,12 @@ export function AllValueListsPanel({ projectId }: Props) {
             placeholder="バリューリスト名で絞り込み..."
             value={filter}
             onChange={handleFilterChange}
-            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
+            className={FILTER_INPUT}
           />
           <button
             onClick={() => setPage((p) => p - 1)}
             disabled={page === 0}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             &lt; 前
           </button>
@@ -69,7 +70,7 @@ export function AllValueListsPanel({ projectId }: Props) {
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={isLastPage}
-            className="px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            className={PAGINATION_BUTTON}
           >
             次 &gt;
           </button>

--- a/src/components/detail/SecurityPanel.tsx
+++ b/src/components/detail/SecurityPanel.tsx
@@ -1,5 +1,6 @@
 import { useAccountList, usePrivilegeSetList } from "../../hooks/security";
 import { Spinner } from "../Spinner";
+import { SECTION_HEADER } from "../../styles/tokens";
 
 interface Props {
   projectId: number;
@@ -19,7 +20,7 @@ export function SecurityPanel({ projectId }: Props) {
     <div className="p-4 space-y-6">
       {/* アカウント */}
       <section>
-        <h2 className="text-sm font-semibold text-gray-700 mb-2">
+        <h2 className={SECTION_HEADER}>
           アカウント ({accounts?.length ?? 0})
         </h2>
         {!accounts || accounts.length === 0 ? (
@@ -51,7 +52,7 @@ export function SecurityPanel({ projectId }: Props) {
 
       {/* 権限セット */}
       <section>
-        <h2 className="text-sm font-semibold text-gray-700 mb-2">
+        <h2 className={SECTION_HEADER}>
           権限セット ({privilegeSets?.length ?? 0})
         </h2>
         {!privilegeSets || privilegeSets.length === 0 ? (

--- a/src/components/detail/ValueListDetail.tsx
+++ b/src/components/detail/ValueListDetail.tsx
@@ -2,6 +2,7 @@
 import { useValueListItems } from "../../hooks/catalog";
 import type { ValueListRow } from "../../types/ddr";
 import { Spinner } from "../Spinner";
+import { SECTION_HEADER } from "../../styles/tokens";
 
 interface Props {
   valueList: ValueListRow;
@@ -29,7 +30,7 @@ export function ValueListDetail({ valueList }: Props) {
       {/* カスタム値一覧 */}
       {valueList.source === "Custom" && (
         <div>
-          <h3 className="text-sm font-semibold text-gray-700 mb-2">値一覧</h3>
+          <h3 className={SECTION_HEADER}>値一覧</h3>
           {items.length === 0 ? (
             <p className="text-gray-500 text-sm">値なし</p>
           ) : (

--- a/src/hooks/analysis.ts
+++ b/src/hooks/analysis.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import type {
   BrokenRef,
   BrokenRefWithProject,
+  ElementRef,
   ProjectRow,
   ReportCard,
   OrphanScript,
@@ -63,6 +64,13 @@ export function useSolutionBrokenRefs(solutionId: number | null) {
     },
     enabled: solutionId !== null,
   });
+}
+
+// 要素名からIDを解決（差分ビューのナビゲーション用）
+export function useResolveElementByName() {
+  return (projectId: number, elementType: string, name: string): Promise<ElementRef | null> =>
+    invoke<ElementRef | null>("resolve_element_by_name", { projectId, elementType, name })
+      .catch(() => null);
 }
 
 // アップグレードチェック

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -1,5 +1,5 @@
 // src/styles/tokens.ts
-// ADR-017: UI スタイルトークン — 全コンポーネント共通のクラス定数
+// UI スタイルトークン — 全コンポーネント共通のクラス定数
 
 /** バッジの基底クラス（色クラスを別途追加する） */
 export const BADGE_BASE = "inline-block text-xs font-medium rounded px-2 py-0.5";

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -40,3 +40,11 @@ export const LIST_ROW = "w-full text-left px-3 py-2 text-sm hover:bg-blue-50 tra
 /** セレクト・インプット標準スタイル */
 export const SELECT_INPUT =
   "border border-gray-300 rounded px-3 py-1.5 text-gray-700 bg-white focus:outline-none focus:ring-1 focus:ring-blue-400";
+
+/** All*Panel 系フィルタ入力（flex-1 + text-sm 込み） */
+export const FILTER_INPUT =
+  "flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded text-gray-700 bg-white focus:outline-none focus:ring-1 focus:ring-blue-400";
+
+/** ページネーションボタン（前ページ・次ページ共通） */
+export const PAGINATION_BUTTON =
+  "px-2 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed";

--- a/src/types/ddr.ts
+++ b/src/types/ddr.ts
@@ -5,6 +5,11 @@ export interface CommandError {
   message: string;
 }
 
+export interface ElementRef {
+  id: number;
+  name: string;
+}
+
 export interface SolutionRow {
   id: number;
   name: string;


### PR DESCRIPTION
## Summary

- `tokens.ts` に `FILTER_INPUT`・`PAGINATION_BUTTON` の 2 つの新規トークンを追加
- `All*Panel` × 9 のフィルター入力・ページネーションボタンをトークンで統一（重複 27 箇所削減）
- `SecurityPanel`・`ValueListDetail` の `SECTION_HEADER` インライン記述をトークンに統一
- `BrokenRefsList`・`OrphanScriptsList`・`ProjectSummaryCard`・`UnusedFieldsList` を `CARD` トークン（`rounded-xl`）に統一
- `DiffCard`・`DiffView` の `invoke("resolve_element_by_name")` 直接呼び出しを `useResolveElementByName` hook に集約（CLAUDE.md 規約準拠）

## 変更内容

| カテゴリ | 変更 | ファイル数 |
|---------|------|-----------|
| 新規トークン | `FILTER_INPUT`・`PAGINATION_BUTTON` 追加 | 1 |
| FILTER_INPUT 適用 | フィルター入力のインライン → トークン（`text-gray-700 bg-white` も明示追加・`SELECT_INPUT` と統一） | 9 |
| PAGINATION_BUTTON 適用 | ページネーションボタンのインライン → トークン | 9 |
| SECTION_HEADER 適用 | インライン → 既存トークン | 2 |
| CARD 統一 | `rounded-lg` → `rounded-xl`（トークン一致） | 4 |
| hook 化 | `DiffCard`・`DiffView` の invoke 直接呼び出しを `hooks/analysis.ts` に移動 | 3 |

## Test plan

- [x] `npm run test` → 381/381 Green（DiffCard・DiffView の hook テスト追加）
- [x] `tsc --noEmit` → エラーなし
- [x] lefthook (typecheck + test) → コミット時に自動通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)